### PR TITLE
Modify application form for dual exam types

### DIFF
--- a/Madmin/application/app_input.php
+++ b/Madmin/application/app_input.php
@@ -23,10 +23,12 @@ $row = [
     'f_category' => $f_category,
     'f_year' => $f_year,
     'f_round' => '',
-    'f_type' => '',
-    'f_registration_period' => '',
-    'f_exam_date' => '',
-    'f_pass_announce' => '',
+    'f_registration_period_written' => '',
+    'f_exam_date_written' => '',
+    'f_pass_announce_written' => '',
+    'f_registration_period_practical' => '',
+    'f_exam_date_practical' => '',
+    'f_pass_announce_practical' => '',
     'f_cert_application' => ''
 ];
 
@@ -115,45 +117,61 @@ $category_map = [
                         </td>
                     </tr>
 
-                    <!-- 구분 (필기/실기) -->
+                    <!-- 필기 일정 -->
                     <tr>
-                        <th><label for="f_type">구분</label></th>
-                        <td colspan="3" class="comALeft">
-                            <select name="f_type" id="f_type" class="form-control" style="width:20%;">
-                                <option value="">선택</option>
-                                <option value="필기" <?= $row['f_type'] === '필기' ? 'selected' : '' ?>>필기</option>
-                                <option value="실기" <?= $row['f_type'] === '실기' ? 'selected' : '' ?>>실기</option>
-                            </select>
-                        </td>
+                        <th colspan="4">필기</th>
                     </tr>
-
-                    <!-- 접수기간 -->
                     <tr>
-                        <th><label for="f_registration_period">접수기간</label></th>
+                        <th><label for="f_registration_period_written">접수기간</label></th>
                         <td colspan="3" class="comALeft">
-                            <input type="text" name="f_registration_period" id="f_registration_period"
-                                value="<?= htmlspecialchars($row['f_registration_period'], ENT_QUOTES) ?>"
+                            <input type="text" name="f_registration_period_written" id="f_registration_period_written"
+                                value="<?= htmlspecialchars($row['f_registration_period_written'], ENT_QUOTES) ?>"
                                 class="form-control" style="width:60%;" placeholder="예: 2025.03.04~10">
                         </td>
                     </tr>
-
-                    <!-- 시험일 -->
                     <tr>
-                        <th><label for="f_exam_date">시험일</label></th>
+                        <th><label for="f_exam_date_written">시험일</label></th>
                         <td colspan="3" class="comALeft">
-                            <input type="text" name="f_exam_date" id="f_exam_date"
-                                value="<?= htmlspecialchars($row['f_exam_date'], ENT_QUOTES) ?>" class="form-control"
+                            <input type="text" name="f_exam_date_written" id="f_exam_date_written"
+                                value="<?= htmlspecialchars($row['f_exam_date_written'], ENT_QUOTES) ?>" class="form-control"
                                 style="width:60%;" placeholder="예: 2025.03.15">
                         </td>
                     </tr>
-
-                    <!-- 합격자 발표 -->
                     <tr>
-                        <th><label for="f_pass_announce">합격자 발표</label></th>
+                        <th><label for="f_pass_announce_written">합격자 발표</label></th>
                         <td colspan="3" class="comALeft">
-                            <input type="text" name="f_pass_announce" id="f_pass_announce"
-                                value="<?= htmlspecialchars($row['f_pass_announce'], ENT_QUOTES) ?>" class="form-control"
+                            <input type="text" name="f_pass_announce_written" id="f_pass_announce_written"
+                                value="<?= htmlspecialchars($row['f_pass_announce_written'], ENT_QUOTES) ?>" class="form-control"
                                 style="width:60%;" placeholder="예: 2025.03.28">
+                        </td>
+                    </tr>
+
+                    <!-- 실기 일정 -->
+                    <tr>
+                        <th colspan="4">실기</th>
+                    </tr>
+                    <tr>
+                        <th><label for="f_registration_period_practical">접수기간</label></th>
+                        <td colspan="3" class="comALeft">
+                            <input type="text" name="f_registration_period_practical" id="f_registration_period_practical"
+                                value="<?= htmlspecialchars($row['f_registration_period_practical'], ENT_QUOTES) ?>"
+                                class="form-control" style="width:60%;" placeholder="예: 2025.04.04~10">
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><label for="f_exam_date_practical">시험일</label></th>
+                        <td colspan="3" class="comALeft">
+                            <input type="text" name="f_exam_date_practical" id="f_exam_date_practical"
+                                value="<?= htmlspecialchars($row['f_exam_date_practical'], ENT_QUOTES) ?>" class="form-control"
+                                style="width:60%;" placeholder="예: 2025.04.15">
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><label for="f_pass_announce_practical">합격자 발표</label></th>
+                        <td colspan="3" class="comALeft">
+                            <input type="text" name="f_pass_announce_practical" id="f_pass_announce_practical"
+                                value="<?= htmlspecialchars($row['f_pass_announce_practical'], ENT_QUOTES) ?>" class="form-control"
+                                style="width:60%;" placeholder="예: 2025.04.28">
                         </td>
                     </tr>
 


### PR DESCRIPTION
## Summary
- allow entering separate schedules for 필기 and 실기
- update default values and remove the old single-type fields

## Testing
- `php -l Madmin/application/app_input.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c83ad88c832290dcc40d53a82d5a