### PR TITLE
Modify application form for dual exam types

### DIFF
--- a/Madmin/application/app_input.php
+++ b/Madmin/application/app_input.php
@@ -23,10 +23,12 @@ $row = [
     'f_category' => $f_category,
     'f_year' => $f_year,
     'f_round' => '',
-    'f_type' => '',
-    'f_registration_period' => '',
-    'f_exam_date' => '',
-    'f_pass_announce' => '',
+    'f_registration_period_written' => '',
+    'f_exam_date_written' => '',
+    'f_pass_announce_written' => '',
+    'f_registration_period_practical' => '',
+    'f_exam_date_practical' => '',
+    'f_pass_announce_practical' => '',
     'f_cert_application' => ''
 ];
 
@@ -64,7 +66,7 @@ $category_map = [
         </ul>
     </div>
 
-    <form action="/Madmin/exec/exec.php?<?= $param ?>" method="post" onsubmit="return confirm('저장하시겠습니까?');">
+    <form action="/Madmin/application/exec.php?<?= $param ?>" method="post" onsubmit="return confirm('저장하시겠습니까?');">
         <input type="hidden" name="table" value="<?= $table ?>">
         <input type="hidden" name="mode" value="<?= $mode ?>">
         <?php if ($idx): ?><input type="hidden" name="idx" value="<?= $idx ?>"><?php endif; ?>
@@ -115,45 +117,61 @@ $category_map = [
                         </td>
                     </tr>
 
-                    <!-- 구분 (필기/실기) -->
+                    <!-- 필기 일정 -->
                     <tr>
-                        <th><label for="f_type">구분</label></th>
-                        <td colspan="3" class="comALeft">
-                            <select name="f_type" id="f_type" class="form-control" style="width:20%;">
-                                <option value="">선택</option>
-                                <option value="필기" <?= $row['f_type'] === '필기' ? 'selected' : '' ?>>필기</option>
-                                <option value="실기" <?= $row['f_type'] === '실기' ? 'selected' : '' ?>>실기</option>
-                            </select>
-                        </td>
+                        <th colspan="4">필기</th>
                     </tr>
-
-                    <!-- 접수기간 -->
                     <tr>
-                        <th><label for="f_registration_period">접수기간</label></th>
+                        <th><label for="f_registration_period_written">접수기간</label></th>
                         <td colspan="3" class="comALeft">
-                            <input type="text" name="f_registration_period" id="f_registration_period"
-                                value="<?= htmlspecialchars($row['f_registration_period'], ENT_QUOTES) ?>"
+                            <input type="text" name="f_registration_period_written" id="f_registration_period_written"
+                                value="<?= htmlspecialchars($row['f_registration_period_written'], ENT_QUOTES) ?>"
                                 class="form-control" style="width:60%;" placeholder="예: 2025.03.04~10">
                         </td>
                     </tr>
-
-                    <!-- 시험일 -->
                     <tr>
-                        <th><label for="f_exam_date">시험일</label></th>
+                        <th><label for="f_exam_date_written">시험일</label></th>
                         <td colspan="3" class="comALeft">
-                            <input type="text" name="f_exam_date" id="f_exam_date"
-                                value="<?= htmlspecialchars($row['f_exam_date'], ENT_QUOTES) ?>" class="form-control"
+                            <input type="text" name="f_exam_date_written" id="f_exam_date_written"
+                                value="<?= htmlspecialchars($row['f_exam_date_written'], ENT_QUOTES) ?>" class="form-control"
                                 style="width:60%;" placeholder="예: 2025.03.15">
                         </td>
                     </tr>
-
-                    <!-- 합격자 발표 -->
                     <tr>
-                        <th><label for="f_pass_announce">합격자 발표</label></th>
+                        <th><label for="f_pass_announce_written">합격자 발표</label></th>
                         <td colspan="3" class="comALeft">
-                            <input type="text" name="f_pass_announce" id="f_pass_announce"
-                                value="<?= htmlspecialchars($row['f_pass_announce'], ENT_QUOTES) ?>" class="form-control"
+                            <input type="text" name="f_pass_announce_written" id="f_pass_announce_written"
+                                value="<?= htmlspecialchars($row['f_pass_announce_written'], ENT_QUOTES) ?>" class="form-control"
                                 style="width:60%;" placeholder="예: 2025.03.28">
+                        </td>
+                    </tr>
+
+                    <!-- 실기 일정 -->
+                    <tr>
+                        <th colspan="4">실기</th>
+                    </tr>
+                    <tr>
+                        <th><label for="f_registration_period_practical">접수기간</label></th>
+                        <td colspan="3" class="comALeft">
+                            <input type="text" name="f_registration_period_practical" id="f_registration_period_practical"
+                                value="<?= htmlspecialchars($row['f_registration_period_practical'], ENT_QUOTES) ?>"
+                                class="form-control" style="width:60%;" placeholder="예: 2025.04.04~10">
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><label for="f_exam_date_practical">시험일</label></th>
+                        <td colspan="3" class="comALeft">
+                            <input type="text" name="f_exam_date_practical" id="f_exam_date_practical"
+                                value="<?= htmlspecialchars($row['f_exam_date_practical'], ENT_QUOTES) ?>" class="form-control"
+                                style="width:60%;" placeholder="예: 2025.04.15">
+                        </td>
+                    </tr>
+                    <tr>
+                        <th><label for="f_pass_announce_practical">합격자 발표</label></th>
+                        <td colspan="3" class="comALeft">
+                            <input type="text" name="f_pass_announce_practical" id="f_pass_announce_practical"
+                                value="<?= htmlspecialchars($row['f_pass_announce_practical'], ENT_QUOTES) ?>" class="form-control"
+                                style="width:60%;" placeholder="예: 2025.04.28">
                         </td>
                     </tr>
 
@@ -180,7 +198,7 @@ $category_map = [
                     <button class="btn btn-info btn-sm" type="submit"><?= $mode === 'insert' ? '등록' : '저장' ?></button>
                     <?php if ($mode === 'update'): ?>
                         <button class="btn btn-danger btn-sm" type="button"
-                            onclick="if(confirm('삭제하시겠습니까?'))location.href='/Madmin/exec/exec.php?table=<?= $table ?>&mode=delete&selidx=<?= $idx ?>&<?= $param ?>';">삭제</button>
+                            onclick="if(confirm('삭제하시겠습니까?'))location.href='/Madmin/application/exec.php?table=<?= $table ?>&mode=delete&selidx=<?= $idx ?>&<?= $param ?>';">삭제</button>
                     <?php endif; ?>
                 </div>
                 <div class="clear"></div>

--- a/Madmin/application/app_list.php
+++ b/Madmin/application/app_list.php
@@ -43,8 +43,7 @@ if ($total > 0) {
         SELECT *
         FROM {$this_table} s
         WHERE 1 = 1 " . $addSql . "
-        -- [변경] 정렬 순서: 회차, 구분 순으로 정렬
-        ORDER BY s.f_round ASC, s.f_type ASC
+        ORDER BY s.f_round ASC, s.idx ASC
         LIMIT " . $offset . ", " . $page_set;
     $list = $db->query($sql);
 }
@@ -86,7 +85,7 @@ $category_map = [
             var selIdx = selIdxArr.join('|');
             // --- [변경] 삭제 후 돌아올 페이지의 파라미터 변경 ---
             var searchParams = "year=<?= $search_year ?>&category=<?= $search_category ?>";
-            document.location = "/Madmin/exec/exec.php?table=<?= $table ?>&mode=delete&selidx=" + selIdx + "&page=<?= $page ?>&" + searchParams;
+            document.location = "/Madmin/application/exec.php?table=<?= $table ?>&mode=delete&selidx=" + selIdx + "&page=<?= $page ?>&" + searchParams;
         }
     }
 </script>
@@ -142,11 +141,13 @@ $category_map = [
                     <col width="40" />
                     <col width="60" />
                     <col width="80" />
-                    <col width="80" />
+                    <col width="180" />
+                    <col width="120" />
+                    <col width="120" />
+                    <col width="180" />
+                    <col width="120" />
+                    <col width="120" />
                     <col width="200" />
-                    <col width="150" />
-                    <col width="150" />
-                    <col />
                     <col width="120" />
                 </colgroup>
                 <thead>
@@ -154,10 +155,12 @@ $category_map = [
                         <th><input type="checkbox" id="select_all" onclick="onSelectAll(this)"></th>
                         <th>번호</th>
                         <th>회차</th>
-                        <th>구분</th>
-                        <th>접수기간</th>
-                        <th>시험일</th>
-                        <th>합격자발표</th>
+                        <th>필기 접수기간</th>
+                        <th>필기 시험일</th>
+                        <th>필기 합격자발표</th>
+                        <th>실기 접수기간</th>
+                        <th>실기 시험일</th>
+                        <th>실기 합격자발표</th>
                         <th>자격증 신청</th>
                         <th>작성일</th>
                     </tr>
@@ -170,22 +173,24 @@ $category_map = [
                                     <input type="checkbox" class="select_checkbox" name="select_checkbox" value="<?= $item['idx'] ?>">
                                 </td>
                                 <td><?= $total - ($page - 1) * $page_set - $i ?></td>
-                                <td><?= htmlspecialchars($item['f_round'], ENT_QUOTES) ?>회</td>
                                 <td class="comALeft">
                                     <a href="<?= $table ?>_input.php?mode=update&idx=<?= $item['idx'] ?>&page=<?= $page ?>&year=<?= $search_year ?>&category=<?= $search_category ?>">
-                                        <?= htmlspecialchars($item['f_type'], ENT_QUOTES) ?>
+                                        <?= htmlspecialchars($item['f_round'], ENT_QUOTES) ?>회
                                     </a>
                                 </td>
-                                <td><?= htmlspecialchars($item['f_registration_period'], ENT_QUOTES) ?></td>
-                                <td><?= htmlspecialchars($item['f_exam_date'], ENT_QUOTES) ?></td>
-                                <td><?= htmlspecialchars($item['f_pass_announce'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($item['f_registration_period_written'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($item['f_exam_date_written'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($item['f_pass_announce_written'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($item['f_registration_period_practical'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($item['f_exam_date_practical'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($item['f_pass_announce_practical'], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($item['f_cert_application'], ENT_QUOTES) ?></td>
                                 <td><?= substr($item['wdate'], 0, 10) ?></td>
                             </tr>
                         <?php endforeach; ?>
                     <?php else: ?>
                         <tr>
-                            <td height="50" colspan="9" class="comACenter">등록된 데이터가 없습니다.</td>
+                            <td height="50" colspan="11" class="comACenter">등록된 데이터가 없습니다.</td>
                         </tr>
                     <?php endif; ?>
                 </tbody>

--- a/Madmin/application/exec.php
+++ b/Madmin/application/exec.php
@@ -1,0 +1,70 @@
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/global.inc';
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/util_lib.inc';
+
+$table = 'df_site_application';
+$mode  = isset($_REQUEST['mode']) ? $_REQUEST['mode'] : '';
+$page  = isset($_REQUEST['page']) ? (int)$_REQUEST['page'] : 1;
+
+// 공통 필드 목록
+$fields = [
+    'f_category',
+    'f_year',
+    'f_round',
+    'f_registration_period_written',
+    'f_exam_date_written',
+    'f_pass_announce_written',
+    'f_registration_period_practical',
+    'f_exam_date_practical',
+    'f_pass_announce_practical',
+    'f_cert_application'
+];
+
+switch ($mode) {
+    case 'insert':
+        $cols = [];
+        $vals = [];
+        $params = [];
+        foreach ($fields as $f) {
+            $cols[] = $f;
+            $vals[] = ':' . $f;
+            $params[$f] = $_POST[$f] ?? '';
+        }
+        $sql = "INSERT INTO {$table} (" . implode(',', $cols) . ", wdate) " .
+               "VALUES (" . implode(',', $vals) . ", NOW())";
+        $db->query($sql, $params);
+        complete('등록되었습니다.', "/Madmin/application/app_list.php?page={$page}");
+        break;
+
+    case 'update':
+        $idx = isset($_POST['idx']) ? (int)$_POST['idx'] : 0;
+        if ($idx <= 0) {
+            error('잘못된 접근입니다.');
+            exit;
+        }
+        $sets = [];
+        $params = [];
+        foreach ($fields as $f) {
+            $sets[] = "$f = :$f";
+            $params[$f] = $_POST[$f] ?? '';
+        }
+        $params['idx'] = $idx;
+        $sql = "UPDATE {$table} SET " . implode(',', $sets) . " WHERE idx = :idx";
+        $db->query($sql, $params);
+        complete('수정되었습니다.', "/Madmin/application/app_list.php?page={$page}");
+        break;
+
+    case 'delete':
+        $selidx = isset($_REQUEST['selidx']) ? $_REQUEST['selidx'] : '';
+        $ids = array_filter(array_map('intval', explode('|', $selidx)));
+        foreach ($ids as $id) {
+            $db->query("DELETE FROM {$table} WHERE idx = :id", ['id' => $id]);
+        }
+        complete('삭제되었습니다.', "/Madmin/application/app_list.php?page={$page}");
+        break;
+
+    default:
+        error('잘못된 모드입니다.');
+        break;
+}
+


### PR DESCRIPTION
## Summary
- allow entering separate schedules for 필기 and 실기
- update list page columns for the new schedule fields
- add `Madmin/application/exec.php` for CRUD handling

## Testing
- `php -l Madmin/application/exec.php` *(fails: command not found)*
- `php -l Madmin/application/app_input.php` *(fails: command not found)*
- `php -l Madmin/application/app_list.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853c83ad88c832290dcc40d53a82d5a