### PR TITLE
Fix checkbox group validation

### DIFF
--- a/center/center_sub_apply.php
+++ b/center/center_sub_apply.php
@@ -571,7 +571,7 @@ $schedules = $db->query("SELECT idx, f_year, f_round, f_type FROM df_site_applic
 																						</li>
 																						<li>
 																							<label class="checkbox_label">
-                                                                               <input type="checkbox" name="f_payment_category[]" value="practical" data-required="y" data-label="입금 구분을" data-tag-type="clicked" />
+                                                                               <input type="checkbox" name="f_payment_category[]" value="practical" data-label="입금 구분을" data-tag-type="clicked" />
 																								<div class="check_icon"></div>
 																								<span>
 																									실기
@@ -580,7 +580,7 @@ $schedules = $db->query("SELECT idx, f_year, f_round, f_type FROM df_site_applic
 																						</li>
 																						<li>
 																							<label class="checkbox_label">
-                                                                               <input type="checkbox" name="f_payment_category[]" value="issuance" data-required="y" data-label="입금 구분을" data-tag-type="clicked" />
+                                                                               <input type="checkbox" name="f_payment_category[]" value="issuance" data-label="입금 구분을" data-tag-type="clicked" />
 																								<div class="check_icon"></div>
 																								<span>
 																									발급비

--- a/js/form-controller.js
+++ b/js/form-controller.js
@@ -19,7 +19,8 @@ class FormValidator {
         },
         clicked: (value, element) => {
             if (element.type === 'checkbox') {
-                return element.checked;
+                const group = this.form.querySelectorAll(`input[name="${element.name}"]`);
+                return Array.from(group).some(chk => chk.checked);
             } else if (element.type === 'radio') {
                 const radioGroup = this.form.querySelectorAll(`input[name="${element.name}"]`);
                 return Array.from(radioGroup).some(radio => radio.checked);


### PR DESCRIPTION
## Summary
- update clicked validation rule to check checkbox groups
- ensure only one '입금 구분' checkbox needs `data-required`

## Testing
- `node --check js/form-controller.js`


------
https://chatgpt.com/codex/tasks/task_e_68579f31ef748322b24fa7eb75ad825a