### PR TITLE
Add category based filtering and improve validation

### DIFF
--- a/js/form-controller.js
+++ b/js/form-controller.js
@@ -19,7 +19,8 @@ class FormValidator {
         },
         clicked: (value, element) => {
             if (element.type === 'checkbox') {
-                return element.checked;
+                const group = this.form.querySelectorAll(`input[name="${element.name}"]`);
+                return Array.from(group).some(cb => cb.checked);
             } else if (element.type === 'radio') {
                 const radioGroup = this.form.querySelectorAll(`input[name="${element.name}"]`);
                 return Array.from(radioGroup).some(radio => radio.checked);

--- a/mypage/modify.html
+++ b/mypage/modify.html
@@ -1455,7 +1455,7 @@ list($c1, $c2, $c3) = explode('-', $row['f_contact_phone']);
     </div>
 </div>
 
-<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
+<script src="https://t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 <script>
     function openPostcode() {
         new daum.Postcode({


### PR DESCRIPTION
## Summary
- pre-select category using GET parameter and disable selection when present
- attach category info to schedule options
- filter item and schedule lists by chosen category
- loosen checkbox validation
- load Kakao postcode API with HTTPS

## Testing
- `php -l center/center_sub_apply.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859000b56888322aeeaeab37c4ffa73