### PR TITLE
Implement dynamic user history page

### DIFF
--- a/mypage/history.html
+++ b/mypage/history.html
@@ -2,7 +2,36 @@
 	$Menu = "07";
 	$sMenu = "07-2";
 
-	include $_SERVER['DOCUMENT_ROOT'].'/include/header.html'; 
+        include $_SERVER['DOCUMENT_ROOT'].'/include/header.html';
+
+        $user_idx = $login_user_info['idx'] ?? 0;
+
+        $exam_rows = $db->query(
+            "SELECT r.idx, i.f_item_name, r.reg_date
+               FROM df_site_application_registration r
+               LEFT JOIN df_site_qualification_item i ON r.f_item_idx = i.idx
+              WHERE r.f_user_idx = :uid AND r.f_application_type = 'exam'
+              ORDER BY r.idx DESC",
+            ['uid' => $user_idx]
+        );
+
+        $cert_rows = $db->query(
+            "SELECT r.idx, i.f_item_name, r.reg_date
+               FROM df_site_application_registration r
+               LEFT JOIN df_site_qualification_item i ON r.f_item_idx = i.idx
+              WHERE r.f_user_idx = :uid AND r.f_application_type = 'cert'
+              ORDER BY r.idx DESC",
+            ['uid' => $user_idx]
+        );
+
+        $edu_rows = $db->query(
+            "SELECT r.idx, b.subject, r.reg_date
+               FROM df_site_edu_registration r
+               LEFT JOIN df_site_bbs b ON r.f_news_idx = b.idx
+              WHERE r.f_user_idx = :uid
+              ORDER BY r.idx DESC",
+            ['uid' => $user_idx]
+        );
 ?>
 
 	<div id="container">
@@ -26,260 +55,154 @@
 								</span>
 							</div>
 
-							<div class="contents_con">
-								
-								<div class="history_con">
-									<ul>
-										<li>
-											<div class="list_div">
-												<div class="title_con">
-													<div class="dot"></div>
+                                                        <div class="contents_con">
 
-													<span>
-														자격증 신청
-													</span>
-												</div>
+                                                                <div class="history_con">
+                                                                        <ul>
+                                                                                <li>
+                                                                                        <div class="list_div">
+                                                                                                <div class="title_con">
+                                                                                                        <div class="dot"></div>
+                                                                                                        <span>자격증 신청</span>
+                                                                                                </div>
 
-												<div class="list_con">
-													<div class="title_con">
-														<table cellpadding="0" cellspacing="0">
-															<tbody>
-																<tr>
-																	<td align="center">
-																		<span>
-																			신청 구분
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			명칭
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			결과
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			날짜
-																		</span>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
+                                                                                                <div class="list_con">
+                                                                                                        <div class="title_con">
+                                                                                                                <table cellpadding="0" cellspacing="0">
+                                                                                                                        <tbody>
+                                                                                                                                <tr>
+                                                                                                                                        <td align="center"><span>신청 구분</span></td>
+                                                                                                                                        <td align="center"><span>명칭</span></td>
+                                                                                                                                        <td align="center"><span>결과</span></td>
+                                                                                                                                        <td align="center"><span>날짜</span></td>
+                                                                                                                                </tr>
+                                                                                                                        </tbody>
+                                                                                                                </table>
+                                                                                                        </div>
 
-													<div class="list_con">
-														<ul>
-															<li>
-																<table cellpadding="0" cellspacing="0">
-																	<tbody>
-																		<tr>
-																			<td align="center">
-																				<span>
-																					신청 구분
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					명칭
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					결과
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					날짜
-																				</span>
-																			</td>
-																		</tr>
-																	</tbody>
-																</table>
-															</li>
-															<!--
-															<li class="none_li">
-																<span>
-																	신청 이력이 없습니다.
-																</span>
-															</li>
-															-->
-														</ul>
-													</div>
-												</div>
-											</div>
-										</li>
-										<li>
-											<div class="list_div">
-												<div class="title_con">
-													<div class="dot"></div>
+                                                                                                        <div class="list_con">
+                                                                                                                <ul>
+                                                                                                                        <?php if (empty($exam_rows)): ?>
+                                                                                                                                <li class="none_li"><span>신청 이력이 없습니다.</span></li>
+                                                                                                                        <?php else: ?>
+                                                                                                                                <?php foreach ($exam_rows as $row): ?>
+                                                                                                                                        <li>
+                                                                                                                                                <table cellpadding="0" cellspacing="0">
+                                                                                                                                                        <tbody>
+                                                                                                                                                                <tr>
+                                                                                                                                                                        <td align="center"><span>시험접수</span></td>
+                                                                                                                                                                        <td align="center"><span><?= htmlspecialchars($row['f_item_name'], ENT_QUOTES) ?></span></td>
+                                                                                                                                                                        <td align="center"><span>접수완료</span></td>
+                                                                                                                                                                        <td align="center"><span><?= date('Y.m.d', strtotime($row['reg_date'])) ?></span></td>
+                                                                                                                                                                </tr>
+                                                                                                                                                        </tbody>
+                                                                                                                                                </table>
+                                                                                                                                        </li>
+                                                                                                                                <?php endforeach; ?>
+                                                                                                                        <?php endif; ?>
+                                                                                                                </ul>
+                                                                                                        </div>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </li>
+                                                                                <li>
+                                                                                        <div class="list_div">
+                                                                                                <div class="title_con">
+                                                                                                        <div class="dot"></div>
+                                                                                                        <span>자격증 발급</span>
+                                                                                                </div>
 
-													<span>
-														자격증 발급
-													</span>
-												</div>
+                                                                                                <div class="list_con">
+                                                                                                        <div class="title_con">
+                                                                                                                <table cellpadding="0" cellspacing="0">
+                                                                                                                        <tbody>
+                                                                                                                                <tr>
+                                                                                                                                        <td align="center"><span>신청 구분</span></td>
+                                                                                                                                        <td align="center"><span>명칭</span></td>
+                                                                                                                                        <td align="center"><span>결과</span></td>
+                                                                                                                                        <td align="center"><span>날짜</span></td>
+                                                                                                                                </tr>
+                                                                                                                        </tbody>
+                                                                                                                </table>
+                                                                                                        </div>
 
-												<div class="list_con">
-													<div class="title_con">
-														<table cellpadding="0" cellspacing="0">
-															<tbody>
-																<tr>
-																	<td align="center">
-																		<span>
-																			신청 구분
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			명칭
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			결과
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			날짜
-																		</span>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
+                                                                                                        <div class="list_con">
+                                                                                                                <ul>
+                                                                                                                        <?php if (empty($cert_rows)): ?>
+                                                                                                                                <li class="none_li"><span>신청 이력이 없습니다.</span></li>
+                                                                                                                        <?php else: ?>
+                                                                                                                                <?php foreach ($cert_rows as $row): ?>
+                                                                                                                                        <li>
+                                                                                                                                                <table cellpadding="0" cellspacing="0">
+                                                                                                                                                        <tbody>
+                                                                                                                                                                <tr>
+                                                                                                                                                                        <td align="center"><span>자격증 발급</span></td>
+                                                                                                                                                                        <td align="center"><span><?= htmlspecialchars($row['f_item_name'], ENT_QUOTES) ?></span></td>
+                                                                                                                                                                        <td align="center"><span>접수완료</span></td>
+                                                                                                                                                                        <td align="center"><span><?= date('Y.m.d', strtotime($row['reg_date'])) ?></span></td>
+                                                                                                                                                                </tr>
+                                                                                                                                                        </tbody>
+                                                                                                                                                </table>
+                                                                                                                                        </li>
+                                                                                                                                <?php endforeach; ?>
+                                                                                                                        <?php endif; ?>
+                                                                                                                </ul>
+                                                                                                        </div>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </li>
+                                                                                <li>
+                                                                                        <div class="list_div">
+                                                                                                <div class="title_con">
+                                                                                                        <div class="dot"></div>
+                                                                                                        <span>교육/세미나 신청</span>
+                                                                                                </div>
 
-													<div class="list_con">
-														<ul>
-															<!--
-															<li>
-																<table cellpadding="0" cellspacing="0">
-																	<tbody>
-																		<tr>
-																			<td align="center">
-																				<span>
-																					신청 구분
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					명칭
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					결과
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					날짜
-																				</span>
-																			</td>
-																		</tr>
-																	</tbody>
-																</table>
-															</li>
-															-->
-															<li class="none_li">
-																<span>
-																	신청 이력이 없습니다.
-																</span>
-															</li>
-														</ul>
-													</div>
-												</div>
-											</div>
-										</li>
-										<li>
-											<div class="list_div">
-												<div class="title_con">
-													<div class="dot"></div>
+                                                                                                <div class="list_con">
+                                                                                                        <div class="title_con">
+                                                                                                                <table cellpadding="0" cellspacing="0">
+                                                                                                                        <tbody>
+                                                                                                                                <tr>
+                                                                                                                                        <td align="center"><span>신청 구분</span></td>
+                                                                                                                                        <td align="center"><span>명칭</span></td>
+                                                                                                                                        <td align="center"><span>결과</span></td>
+                                                                                                                                        <td align="center"><span>날짜</span></td>
+                                                                                                                                </tr>
+                                                                                                                        </tbody>
+                                                                                                                </table>
+                                                                                                        </div>
 
-													<span>
-														교육/세미나 신청
-													</span>
-												</div>
+                                                                                                        <div class="list_con">
+                                                                                                                <ul>
+                                                                                                                        <?php if (empty($edu_rows)): ?>
+                                                                                                                                <li class="none_li"><span>신청 이력이 없습니다.</span></li>
+                                                                                                                        <?php else: ?>
+                                                                                                                                <?php foreach ($edu_rows as $row): ?>
+                                                                                                                                        <li>
+                                                                                                                                                <table cellpadding="0" cellspacing="0">
+                                                                                                                                                        <tbody>
+                                                                                                                                                                <tr>
+                                                                                                                                                                        <td align="center"><span>교육/세미나</span></td>
+                                                                                                                                                                        <td align="center"><span><?= htmlspecialchars($row['subject'], ENT_QUOTES) ?></span></td>
+                                                                                                                                                                        <td align="center"><span>접수완료</span></td>
+                                                                                                                                                                        <td align="center"><span><?= date('Y.m.d', strtotime($row['reg_date'])) ?></span></td>
+                                                                                                                                                                </tr>
+                                                                                                                                                        </tbody>
+                                                                                                                                                </table>
+                                                                                                                                        </li>
+                                                                                                                                <?php endforeach; ?>
+                                                                                                                        <?php endif; ?>
+                                                                                                                </ul>
+                                                                                                        </div>
+                                                                                                </div>
+                                                                                        </div>
+                                                                                </li>
+                                                                        </ul>
+                                                                </div>
 
-												<div class="list_con">
-													<div class="title_con">
-														<table cellpadding="0" cellspacing="0">
-															<tbody>
-																<tr>
-																	<td align="center">
-																		<span>
-																			신청 구분
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			명칭
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			결과
-																		</span>
-																	</td>
-																	<td align="center">
-																		<span>
-																			날짜
-																		</span>
-																	</td>
-																</tr>
-															</tbody>
-														</table>
-													</div>
+                                                        </div>
 
-													<div class="list_con">
-														<ul>
-															<!--
-															<li>
-																<table cellpadding="0" cellspacing="0">
-																	<tbody>
-																		<tr>
-																			<td align="center">
-																				<span>
-																					신청 구분
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					명칭
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					결과
-																				</span>
-																			</td>
-																			<td align="center">
-																				<span>
-																					날짜
-																				</span>
-																			</td>
-																		</tr>
-																	</tbody>
-																</table>
-															</li>
-															-->
-															<li class="none_li">
-																<span>
-																	신청 이력이 없습니다.
-																</span>
-															</li>
-														</ul>
-													</div>
-												</div>
-											</div>
-										</li>
-									</ul>
-								</div>
-
-							</div>
+                                                        </div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
## Summary
- implement dynamic history retrieval for user page
- query application, certificate, and education history by logged-in user
- render lists for each history section with a fallback message when no records exist

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68596ee7679c8322986e054e27c896ec