### PR TITLE
Improve readability of registration views

### DIFF
--- a/Madmin/registration/reg_application_view.php
+++ b/Madmin/registration/reg_application_view.php
@@ -11,30 +11,23 @@ if (!$row) {
     exit;
 }
 
-// 컬럼명 대신 화면에 표시할 한글 라벨 매핑
-$labels = [
-    'f_applicant_type'   => '신청자구분',
-    'f_category'         => '자격분야',
-    'f_item_idx'         => '자격종목',
-    'f_schedule_idx'     => '시험일정',
-    'f_user_name'        => '이름',
-    'f_user_name_en'     => '영문이름',
-    'f_tel'              => '연락처',
-    'f_contact_phone'    => '담당자 연락처',
-    'f_birth_date'       => '생년월일',
-    'f_zip'              => '우편번호',
-    'f_address1'         => '기본주소',
-    'f_address2'         => '상세주소',
-    'f_email'            => '이메일',
-    'f_application_type' => '신청구분',
-    'f_issue_desire'     => '발급희망 여부',
-    'f_issue_file'       => '사진첨부',
-    'f_payer_name'       => '입금자명',
-    'f_payer_bank'       => '은행',
-    'f_payment_category' => '입금 구분',
-    'f_user_id'          => '회원ID',
-    'reg_date'           => '등록일',
-];
+// 값 출력 시 사용될 공통 함수
+function printValue($val)
+{
+    return nl2br(safeAdminOutput($val));
+}
+
+function printType($val)
+{
+    switch ($val) {
+        case 'P':
+            return '개인';
+        case 'O':
+            return '단체';
+        default:
+            return safeAdminOutput($val);
+    }
+}
 ?>
 <div class="pageWrap">
     <div class="page-heading">
@@ -47,14 +40,90 @@ $labels = [
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table noMargin" cellpadding="0" cellspacing="0">
-                <?php foreach ($row as $key => $val): ?>
-                    <?php if ($key === 'idx') continue; ?>
-                    <?php if (!isset($labels[$key])) continue; ?>
-                    <tr>
-                        <td style="width:200px;"><?= htmlspecialchars($labels[$key], ENT_QUOTES) ?></td>
-                        <td><?= nl2br(htmlspecialchars($val, ENT_QUOTES)) ?></td>
-                    </tr>
-                <?php endforeach; ?>
+                <tr>
+                    <td style="width:200px;">신청자구분</td>
+                    <td><?= printType($row['f_applicant_type']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">자격분야</td>
+                    <td><?= printValue($row['f_category']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">자격종목</td>
+                    <td><?= printValue($row['f_item_idx']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">시험일정</td>
+                    <td><?= printValue($row['f_schedule_idx']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">이름</td>
+                    <td><?= printValue($row['f_user_name']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">영문이름</td>
+                    <td><?= printValue($row['f_user_name_en']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">연락처</td>
+                    <td><?= printValue($row['f_tel']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">담당자 연락처</td>
+                    <td><?= printValue($row['f_contact_phone']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">생년월일</td>
+                    <td><?= printValue($row['f_birth_date']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">우편번호</td>
+                    <td><?= printValue($row['f_zip']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">기본주소</td>
+                    <td><?= printValue($row['f_address1']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">상세주소</td>
+                    <td><?= printValue($row['f_address2']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">이메일</td>
+                    <td><?= printValue($row['f_email']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">신청구분</td>
+                    <td><?= printValue($row['f_application_type']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">발급희망 여부</td>
+                    <td><?= printValue($row['f_issue_desire']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">사진첨부</td>
+                    <td><?= printValue($row['f_issue_file']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">입금자명</td>
+                    <td><?= printValue($row['f_payer_name']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">은행</td>
+                    <td><?= printValue($row['f_payer_bank']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">입금 구분</td>
+                    <td><?= printValue($row['f_payment_category']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">회원ID</td>
+                    <td><?= printValue($row['f_user_id']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">등록일</td>
+                    <td><?= printValue($row['reg_date']) ?></td>
+                </tr>
             </table>
         </div>
     </div>

--- a/Madmin/registration/reg_competition_view.php
+++ b/Madmin/registration/reg_competition_view.php
@@ -10,29 +10,24 @@ if (!$row) {
     error('잘못된 접근입니다.', 'competition_list.php');
     exit;
 }
+// 값 출력 시 사용될 공통 함수
+function printValue($val)
+{
+    return nl2br(safeAdminOutput($val));
+}
 
-// 컬럼명 대신 보여줄 라벨 정의
-$labels = [
-    'f_applicant_type'   => '신청자구분',
-    'f_competition_idx'  => '대회구분',
-    'f_part'             => '참가부문',
-    'f_field'            => '종목분야',
-    'f_event'            => '참가종목',
-    'f_user_name'        => '이름',
-    'f_gender'           => '성별',
-    'f_user_name_en'     => '영문이름',
-    'f_birth_date'       => '생년월일',
-    'f_tel'              => '연락처',
-    'f_email'            => '이메일',
-    'f_zip'              => '우편번호',
-    'f_address1'         => '기본주소',
-    'f_address2'         => '상세주소',
-    'f_payer_name'       => '입금자명',
-    'f_payer_bank'       => '은행',
-    'f_payment_category' => '입금 구분',
-    'f_user_id'          => '회원ID',
-    'reg_date'           => '등록일',
-];
+function printType($val)
+{
+    switch ($val) {
+        case 'P':
+            return '개인';
+        case 'O':
+            return '단체';
+        default:
+            return safeAdminOutput($val);
+    }
+}
+
 ?>
 <div class="pageWrap">
     <div class="page-heading">
@@ -45,14 +40,82 @@ $labels = [
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table noMargin" cellpadding="0" cellspacing="0">
-                <?php foreach ($row as $key => $val): ?>
-                    <?php if ($key === 'idx') continue; ?>
-                    <?php if (!isset($labels[$key])) continue; ?>
-                    <tr>
-                        <td style="width:200px;"><?= htmlspecialchars($labels[$key], ENT_QUOTES) ?></td>
-                        <td><?= nl2br(htmlspecialchars($val, ENT_QUOTES)) ?></td>
-                    </tr>
-                <?php endforeach; ?>
+                <tr>
+                    <td style="width:200px;">신청자구분</td>
+                    <td><?= printType($row['f_applicant_type']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">대회구분</td>
+                    <td><?= printValue($row['f_competition_idx']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">참가부문</td>
+                    <td><?= printValue($row['f_part']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">종목분야</td>
+                    <td><?= printValue($row['f_field']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">참가종목</td>
+                    <td><?= printValue($row['f_event']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">이름</td>
+                    <td><?= printValue($row['f_user_name']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">성별</td>
+                    <td><?= printValue($row['f_gender']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">영문이름</td>
+                    <td><?= printValue($row['f_user_name_en']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">생년월일</td>
+                    <td><?= printValue($row['f_birth_date']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">연락처</td>
+                    <td><?= printValue($row['f_tel']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">이메일</td>
+                    <td><?= printValue($row['f_email']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">우편번호</td>
+                    <td><?= printValue($row['f_zip']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">기본주소</td>
+                    <td><?= printValue($row['f_address1']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">상세주소</td>
+                    <td><?= printValue($row['f_address2']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">입금자명</td>
+                    <td><?= printValue($row['f_payer_name']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">은행</td>
+                    <td><?= printValue($row['f_payer_bank']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">입금 구분</td>
+                    <td><?= printValue($row['f_payment_category']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">회원ID</td>
+                    <td><?= printValue($row['f_user_id']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">등록일</td>
+                    <td><?= printValue($row['reg_date']) ?></td>
+                </tr>
             </table>
         </div>
     </div>

--- a/Madmin/registration/reg_edu_view.php
+++ b/Madmin/registration/reg_edu_view.php
@@ -11,28 +11,24 @@ if (!$row) {
     exit;
 }
 
+// 값 출력 시 사용될 공통 함수
+function printValue($val)
+{
+    return nl2br(safeAdminOutput($val));
+}
+
+function printType($val)
+{
+    switch ($val) {
+        case 'P':
+            return '개인';
+        case 'O':
+            return '단체';
+        default:
+            return safeAdminOutput($val);
+    }
+}
 // 컬럼명과 한글 라벨 매핑
-$labels = [
-    'f_type'            => '구분',
-    'f_news_idx'        => '교육구분',
-    'f_user_name'       => '이름/기관명',
-    'f_user_name_en'    => '영문이름/담당자',
-    'f_gender'          => '성별',
-    'f_birth_date'      => '생년월일',
-    'f_tel'             => '연락처',
-    'f_contact_phone'   => '담당자 연락처',
-    'f_zip'             => '우편번호',
-    'f_address1'        => '기본주소',
-    'f_address2'        => '상세주소',
-    'f_email'           => '이메일',
-    'f_issue_file'      => '파일',
-    'f_issue_file_name' => '파일명',
-    'f_payer_name'      => '입금자명',
-    'f_payer_bank'      => '은행',
-    'f_payment_category'=> '입금 구분',
-    'f_user_id'         => '회원ID',
-    'reg_date'          => '등록일',
-];
 ?>
 <div class="pageWrap">
     <div class="page-heading">
@@ -45,16 +41,82 @@ $labels = [
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table noMargin" cellpadding="0" cellspacing="0">
-                <?php foreach ($row as $key => $val): ?>
-                    <?php if ($key === 'idx') continue; ?>
-                    <?php if (!isset($labels[$key])) continue; ?>
-                    <tr>
-                        <td style="width:200px;">
-                            <?= htmlspecialchars($labels[$key], ENT_QUOTES) ?>
-                        </td>
-                        <td><?= nl2br(htmlspecialchars($val, ENT_QUOTES)) ?></td>
-                    </tr>
-                <?php endforeach; ?>
+                <tr>
+                    <td style="width:200px;">구분</td>
+                    <td><?= printType($row['f_type']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">교육구분</td>
+                    <td><?= printValue($row['f_news_idx']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">이름/기관명</td>
+                    <td><?= printValue($row['f_user_name']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">영문이름/담당자</td>
+                    <td><?= printValue($row['f_user_name_en']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">성별</td>
+                    <td><?= printValue($row['f_gender']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">생년월일</td>
+                    <td><?= printValue($row['f_birth_date']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">연락처</td>
+                    <td><?= printValue($row['f_tel']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">담당자 연락처</td>
+                    <td><?= printValue($row['f_contact_phone']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">우편번호</td>
+                    <td><?= printValue($row['f_zip']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">기본주소</td>
+                    <td><?= printValue($row['f_address1']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">상세주소</td>
+                    <td><?= printValue($row['f_address2']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">이메일</td>
+                    <td><?= printValue($row['f_email']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">파일</td>
+                    <td><?= printValue($row['f_issue_file']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">파일명</td>
+                    <td><?= printValue($row['f_issue_file_name']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">입금자명</td>
+                    <td><?= printValue($row['f_payer_name']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">은행</td>
+                    <td><?= printValue($row['f_payer_bank']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">입금 구분</td>
+                    <td><?= printValue($row['f_payment_category']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">회원ID</td>
+                    <td><?= printValue($row['f_user_id']) ?></td>
+                </tr>
+                <tr>
+                    <td style="width:200px;">등록일</td>
+                    <td><?= printValue($row['reg_date']) ?></td>
+                </tr>
             </table>
         </div>
     </div>


### PR DESCRIPTION
## Summary
- expand registration detail views with explicit table rows
- show user-friendly type names
- replace foreach loops with clear labels

## Testing
- `php -l Madmin/registration/reg_application_view.php` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_685b7f56969483228f3310bf1fed4880