### PR TITLE
Implement simple PHPMailer SMTP mailer

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,17 @@
 
 ## 배포
 웹 서버의 Document Root 하위에 전체 파일을 업로드하면 동작합니다. 관리자 페이지는 `/Madmin` 경로로 접속합니다.
+
+## 메일 발송 설정
+네이버 SMTP를 통해 메일을 보내려면 `lib/settings.ini.php`의 `[SMTP]` 항목에 계정 정보를 입력합니다.
+
+```
+[SMTP]
+host = smtp.naver.com
+port = 465
+user = your_naver_id
+password = "your_password"
+secure = ssl
+```
+
+네이버 메일 환경설정에서 POP3/SMTP 사용을 허용해야 하며, 필요하다면 앱 비밀번호를 사용합니다.

--- a/inc/util_lib.inc
+++ b/inc/util_lib.inc
@@ -896,19 +896,35 @@ function print_pagelist_web($page, $list_amount, $page_count, $param)
 // 이메일 발송
 function send_mail($se_name, $se_email, $re_name, $re_email, $subject, $content, $cc = "", $bcc = "")
 {
+        require_once $_SERVER['DOCUMENT_ROOT'] . "/lib/PHPMailer/Exception.php";
+        require_once $_SERVER['DOCUMENT_ROOT'] . "/lib/PHPMailer/PHPMailer.php";
 
-	$headers = "MIME-Version: 1.0\r\n";
-	$headers .= "From: =?utf-8?b?" . base64_encode($se_name) . "?= <" . $se_email . ">\r\n";
-	$headers .= "Content-Type: text/html;charset=utf-8\r\n";
-	$headers .= "Reply-To: $reply\r\n";
-	$headers .= "X-Mailer: PHP/" . phpversion();
+        $config = parse_ini_file($_SERVER['DOCUMENT_ROOT'] . "/lib/settings.ini.php", true);
+        $smtp = $config['SMTP'];
 
-	if ($cc) $headers .= "cc: $cc\n";
-	if ($bcc) $headers .= "bcc: $bcc";
+        $mail = new PHPMailer\PHPMailer\PHPMailer();
+        $mail->isSMTP();
+        $mail->Host = $smtp['host'];
+        $mail->Port = $smtp['port'];
+        $mail->SMTPAuth = true;
+        $mail->Username = $smtp['user'];
+        $mail->Password = $smtp['password'];
+        $mail->SMTPSecure = $smtp['secure'];
 
-	$subject = "=?UTF-8?B?" . base64_encode($subject) . "?=";
-	$result = mail($re_email, $subject, $content, $headers);
-	return $result;
+        $mail->setFrom($se_email, $se_name);
+        $mail->addAddress($re_email, $re_name);
+        if ($cc) $mail->addCC($cc);
+        if ($bcc) $mail->addBCC($bcc);
+
+        $mail->Subject = $subject;
+        $mail->isHTML(true);
+        $mail->Body = $content;
+
+        try {
+                return $mail->send();
+        } catch (\PHPMailer\PHPMailer\Exception $e) {
+                return false;
+        }
 }
 
 

--- a/lib/PHPMailer/Exception.php
+++ b/lib/PHPMailer/Exception.php
@@ -1,0 +1,3 @@
+<?php
+namespace PHPMailer\PHPMailer;
+class Exception extends \Exception {}

--- a/lib/PHPMailer/PHPMailer.php
+++ b/lib/PHPMailer/PHPMailer.php
@@ -1,0 +1,91 @@
+<?php
+namespace PHPMailer\PHPMailer;
+
+class PHPMailer {
+    public $Host = 'localhost';
+    public $Port = 25;
+    public $Username = '';
+    public $Password = '';
+    public $SMTPSecure = '';
+    public $SMTPAuth = false;
+    public $From = '';
+    public $FromName = '';
+    public $Subject = '';
+    public $Body = '';
+    protected $to = [];
+    protected $cc = [];
+    protected $bcc = [];
+    protected $isHTML = false;
+    protected $isSMTP = false;
+
+    public function isSMTP() { $this->isSMTP = true; }
+    public function setFrom($address, $name = '') { $this->From = $address; $this->FromName = $name; }
+    public function addAddress($address, $name = '') { $this->to[] = ['address'=>$address,'name'=>$name]; }
+    public function addCC($address, $name = '') { $this->cc[] = ['address'=>$address,'name'=>$name]; }
+    public function addBCC($address, $name = '') { $this->bcc[] = ['address'=>$address,'name'=>$name]; }
+    public function isHTML($bool = true) { $this->isHTML = $bool; }
+
+    protected function expect($fp, $code) {
+        $line = '';
+        while ($line === '' || $line[3] != ' ') {
+            $line = fgets($fp, 515);
+        }
+        if (substr($line,0,3) != $code) {
+            throw new Exception('SMTP error: '.$line);
+        }
+    }
+
+    public function send() {
+        if (!$this->isSMTP) {
+            $headers = "From: {$this->FromName} <{$this->From}>\r\n";
+            if ($this->isHTML) $headers .= "Content-Type: text/html; charset=utf-8\r\n";
+            $to = array_map(function($x){return $x['address'];}, $this->to);
+            if ($this->cc) $headers .= 'Cc: '.implode(',', array_map(function($x){return $x["address"];}, $this->cc))."\r\n";
+            if ($this->bcc) $headers .= 'Bcc: '.implode(',', array_map(function($x){return $x["address"];}, $this->bcc))."\r\n";
+            return mail(implode(',', $to), $this->Subject, $this->Body, $headers);
+        }
+        $host = ($this->SMTPSecure=='ssl'?'ssl://':'').$this->Host;
+        $fp = fsockopen($host, $this->Port, $errno, $errstr, 10);
+        if (!$fp) return false;
+        $this->expect($fp, 220);
+        $local = gethostname();
+        fwrite($fp, "EHLO {$local}\r\n");
+        $this->expect($fp, 250);
+        if ($this->SMTPSecure=='tls') {
+            fwrite($fp, "STARTTLS\r\n");
+            $this->expect($fp, 220);
+            stream_socket_enable_crypto($fp, true, STREAM_CRYPTO_METHOD_TLS_CLIENT);
+            fwrite($fp, "EHLO {$local}\r\n");
+            $this->expect($fp, 250);
+        }
+        if ($this->SMTPAuth) {
+            fwrite($fp, "AUTH LOGIN\r\n");
+            $this->expect($fp, 334);
+            fwrite($fp, base64_encode($this->Username)."\r\n");
+            $this->expect($fp, 334);
+            fwrite($fp, base64_encode($this->Password)."\r\n");
+            $this->expect($fp, 235);
+        }
+        fwrite($fp, "MAIL FROM:<{$this->From}>\r\n");
+        $this->expect($fp, 250);
+        $all = array_merge($this->to,$this->cc,$this->bcc);
+        foreach ($all as $addr) {
+            fwrite($fp, "RCPT TO:<{$addr['address']}>\r\n");
+            $this->expect($fp, 250);
+        }
+        fwrite($fp, "DATA\r\n");
+        $this->expect($fp, 354);
+        $headers = "From: {$this->FromName} <{$this->From}>\r\n";
+        $toHdr = implode(',', array_map(function($x){return $x['address'];}, $this->to));
+        $headers .= "To: {$toHdr}\r\n";
+        if ($this->cc) $headers .= 'Cc: '.implode(',', array_map(function($x){return $x["address"];}, $this->cc))."\r\n";
+        if ($this->bcc) $headers .= 'Bcc: '.implode(',', array_map(function($x){return $x["address"];}, $this->bcc))."\r\n";
+        $headers .= "Subject: {$this->Subject}\r\n";
+        if ($this->isHTML) $headers .= "Content-Type: text/html; charset=utf-8\r\n";
+        fwrite($fp, $headers."\r\n".$this->Body."\r\n.\r\n");
+        $this->expect($fp, 250);
+        fwrite($fp, "QUIT\r\n");
+        fclose($fp);
+        return true;
+    }
+}

--- a/lib/settings.ini.php
+++ b/lib/settings.ini.php
@@ -3,3 +3,10 @@ host = db.kbga8800.gabia.io
 user = kbga8800
 password = "oitori0619#"
 dbname = dbkbga8800
+
+[SMTP]
+host = smtp.naver.com
+port = 465
+user = your_naver_id
+password = "your_password"
+secure = ssl


### PR DESCRIPTION
## Summary
- add basic PHPMailer library without Composer
- configure SMTP settings in `settings.ini.php`
- switch `send_mail()` to PHPMailer based SMTP
- document SMTP setup in README

## Testing
- `php` not available so syntax not tested


------
https://chatgpt.com/codex/tasks/task_e_6861f94b24dc83229ced103ee2a316b9