### PR TITLE
Fix registration Excel export

### DIFF
--- a/Madmin/registration/reg_competition_excel.php
+++ b/Madmin/registration/reg_competition_excel.php
@@ -2,28 +2,18 @@
 include "../../inc/global.inc";
 include "../../inc/util_lib.inc";
 
-$filename = iconv('UTF-8', 'EUC-KR', "자격시험신청_" . date('Ymd') . ".xls");
+$filename = iconv('UTF-8', 'EUC-KR', "대회신청_" . date('Ymd') . ".xls");
 
 header("Content-Type: application/vnd.ms-excel; charset=UTF-8");
 header("Content-Disposition: attachment; filename={$filename}");
 header("Content-Description: PHP Generated Data");
 
-$category_map = [
-    'makeup'  => '메이크업',
-    'nail'    => '네일',
-    'hair'    => '헤어',
-    'skin'    => '피부',
-    'half'    => '반영구',
-    'foreign' => '해외인증',
-    'teacher' => '강사인증',
-];
-
-$list = $db->query("SELECT * FROM df_site_application_registration ORDER BY idx DESC");
+$list = $db->query("SELECT * FROM df_site_competition_registration ORDER BY idx DESC");
 
 echo "<table border='1'>";
 echo "<tr>";
 echo "<th>번호</th>";
-echo "<th>분야</th>";
+echo "<th>참가분야</th>";
 echo "<th>이름</th>";
 echo "<th>연락처</th>";
 echo "<th>이메일</th>";
@@ -31,10 +21,9 @@ echo "</tr>";
 
 $no = count($list);
 foreach ($list as $row) {
-    $category = $category_map[$row['f_category']] ?? '';
     echo "<tr>";
     echo "<td>{$no}</td>";
-    echo "<td>" . safeAdminOutput($category) . "</td>";
+    echo "<td>" . safeAdminOutput($row['f_field']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_user_name']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_tel']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_email']) . "</td>";

--- a/Madmin/registration/reg_competition_list.php
+++ b/Madmin/registration/reg_competition_list.php
@@ -33,6 +33,15 @@ if ($total > 0) {
             <li class="active">대회</li>
         </ul>
     </div>
+    <table class="comMTop20" cellpadding="0" cellspacing="0" style="width:1114px;">
+        <tr>
+            <td width="5"></td>
+            <td colspan="6" align="right">
+                <button class="btn btn-success btn-xs" type="button" onclick="location.href='reg_competition_excel.php?<?= $param ?>'">엑셀파일저장</button>
+            </td>
+            <td width="5"></td>
+        </tr>
+    </table>
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table" cellpadding="0" cellspacing="0">

--- a/Madmin/registration/reg_edu_excel.php
+++ b/Madmin/registration/reg_edu_excel.php
@@ -2,28 +2,18 @@
 include "../../inc/global.inc";
 include "../../inc/util_lib.inc";
 
-$filename = iconv('UTF-8', 'EUC-KR', "자격시험신청_" . date('Ymd') . ".xls");
+$filename = iconv('UTF-8', 'EUC-KR', "교육신청_" . date('Ymd') . ".xls");
 
 header("Content-Type: application/vnd.ms-excel; charset=UTF-8");
 header("Content-Disposition: attachment; filename={$filename}");
 header("Content-Description: PHP Generated Data");
 
-$category_map = [
-    'makeup'  => '메이크업',
-    'nail'    => '네일',
-    'hair'    => '헤어',
-    'skin'    => '피부',
-    'half'    => '반영구',
-    'foreign' => '해외인증',
-    'teacher' => '강사인증',
-];
-
-$list = $db->query("SELECT * FROM df_site_application_registration ORDER BY idx DESC");
+$list = $db->query("SELECT * FROM df_site_edu_registration ORDER BY idx DESC");
 
 echo "<table border='1'>";
 echo "<tr>";
 echo "<th>번호</th>";
-echo "<th>분야</th>";
+echo "<th>구분</th>";
 echo "<th>이름</th>";
 echo "<th>연락처</th>";
 echo "<th>이메일</th>";
@@ -31,10 +21,9 @@ echo "</tr>";
 
 $no = count($list);
 foreach ($list as $row) {
-    $category = $category_map[$row['f_category']] ?? '';
     echo "<tr>";
     echo "<td>{$no}</td>";
-    echo "<td>" . safeAdminOutput($category) . "</td>";
+    echo "<td>" . safeAdminOutput($row['f_type']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_user_name']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_tel']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_email']) . "</td>";

--- a/Madmin/registration/reg_edu_list.php
+++ b/Madmin/registration/reg_edu_list.php
@@ -33,6 +33,15 @@ if ($total > 0) {
             <li class="active">교육</li>
         </ul>
     </div>
+    <table class="comMTop20" cellpadding="0" cellspacing="0" style="width:1114px;">
+        <tr>
+            <td width="5"></td>
+            <td colspan="6" align="right">
+                <button class="btn btn-success btn-xs" type="button" onclick="location.href='reg_edu_excel.php?<?= $param ?>'">엑셀파일저장</button>
+            </td>
+            <td width="5"></td>
+        </tr>
+    </table>
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table" cellpadding="0" cellspacing="0">


### PR DESCRIPTION
## Summary
- reg_application_excel.php 파일을 간단한 엑셀 다운로드 스크립트로 교체했습니다
- 대회/교육/자격시험 리스트에서 엑셀 저장 버튼을 유지했습니다

## Testing
- `php -v` *(실패: `php` 명령어 없음)*

------
https://chatgpt.com/codex/tasks/task_e_686231fdd2988322a74851fd20139f06