### PR TITLE
Display referenced names in registration views

### DIFF
--- a/Madmin/registration/reg_application_view.php
+++ b/Madmin/registration/reg_application_view.php
@@ -4,8 +4,11 @@ include $_SERVER['DOCUMENT_ROOT'] . "/Madmin/inc/top.php";
 $idx = isset($_GET['idx']) ? (int) $_GET['idx'] : 0;
 $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
 
-$sql = "SELECT t1.*, t2.f_item_name FROM df_site_application_registration t1
+$sql = "SELECT t1.*, t2.f_item_name,
+               s.f_year, s.f_round, s.f_type
+        FROM df_site_application_registration t1
         LEFT JOIN df_site_qualification_item t2 ON t1.f_item_idx = t2.idx
+        LEFT JOIN df_site_application s ON t1.f_schedule_idx = s.idx
         WHERE t1.idx = '{$idx}'";
 
 $row = $db->row($sql);
@@ -30,6 +33,14 @@ function printType($val)
         default:
             return safeAdminOutput($val);
     }
+}
+
+function printSchedule(array $row)
+{
+    if (!empty($row['f_year'])) {
+        return printValue(sprintf('%s년 %s회차 %s', $row['f_year'], $row['f_round'], $row['f_type']));
+    }
+    return printValue($row['f_schedule_idx']);
 }
 
 $category_map = [
@@ -67,7 +78,7 @@ $category_map = [
                 </tr>
                 <tr>
                     <td style="width:200px;">시험일정</td>
-                    <td><?= printValue($row['f_schedule_idx']) ?></td>
+                    <td><?= printSchedule($row) ?></td>
                 </tr>
                 <tr>
                     <td style="width:200px;">이름</td>

--- a/Madmin/registration/reg_application_view_excel.php
+++ b/Madmin/registration/reg_application_view_excel.php
@@ -4,8 +4,11 @@ include "../../inc/util_lib.inc";
 
 $idx = isset($_GET['idx']) ? (int)$_GET['idx'] : 0;
 
-$sql = "SELECT t1.*, t2.f_item_name FROM df_site_application_registration t1
+$sql = "SELECT t1.*, t2.f_item_name,
+        s.f_year, s.f_round, s.f_type
+        FROM df_site_application_registration t1
         LEFT JOIN df_site_qualification_item t2 ON t1.f_item_idx = t2.idx
+        LEFT JOIN df_site_application s ON t1.f_schedule_idx = s.idx
         WHERE t1.idx = '{$idx}'";
 $row = $db->row($sql);
 if (!$row) {
@@ -27,6 +30,14 @@ function printType($val)
         default:
             return safeAdminOutput($val);
     }
+}
+
+function printSchedule(array $row)
+{
+    if (!empty($row['f_year'])) {
+        return printValue(sprintf('%s년 %s회차 %s', $row['f_year'], $row['f_round'], $row['f_type']));
+    }
+    return printValue($row['f_schedule_idx']);
 }
 
 $category_map = [
@@ -51,7 +62,7 @@ $rows = [
     '신청자구분'     => printType($row['f_applicant_type']),
     '자격분야'       => printValue($category_map[$row['f_category']]),
     '자격종목'       => printValue($row['f_item_name']),
-    '시험일정'       => printValue($row['f_schedule_idx']),
+    '시험일정'       => printSchedule($row),
     '이름'           => printValue($row['f_user_name']),
     '영문이름'       => printValue($row['f_user_name_en']),
     '연락처'         => printValue($row['f_tel']),

--- a/Madmin/registration/reg_competition_view.php
+++ b/Madmin/registration/reg_competition_view.php
@@ -4,7 +4,10 @@ include $_SERVER['DOCUMENT_ROOT'] . "/Madmin/inc/top.php";
 $idx = isset($_GET['idx']) ? (int) $_GET['idx'] : 0;
 $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
 
-$sql = "SELECT * FROM df_site_competition_registration WHERE idx = '{$idx}'";
+$sql = "SELECT t1.*, c.f_title
+        FROM df_site_competition_registration t1
+        LEFT JOIN df_site_competition c ON t1.f_competition_idx = c.idx
+        WHERE t1.idx = '{$idx}'";
 $row = $db->row($sql);
 if (!$row) {
     error('잘못된 접근입니다.', 'competition_list.php');
@@ -46,7 +49,7 @@ function printType($val)
                 </tr>
                 <tr>
                     <td style="width:200px;">대회구분</td>
-                    <td><?= printValue($row['f_competition_idx']) ?></td>
+                    <td><?= printValue($row['f_title']) ?></td>
                 </tr>
                 <tr>
                     <td style="width:200px;">참가부문</td>

--- a/Madmin/registration/reg_competition_view_excel.php
+++ b/Madmin/registration/reg_competition_view_excel.php
@@ -4,7 +4,10 @@ include "../../inc/util_lib.inc";
 
 $idx = isset($_GET['idx']) ? (int)$_GET['idx'] : 0;
 
-$sql = "SELECT * FROM df_site_competition_registration WHERE idx = '{$idx}'";
+$sql = "SELECT t1.*, c.f_title
+        FROM df_site_competition_registration t1
+        LEFT JOIN df_site_competition c ON t1.f_competition_idx = c.idx
+        WHERE t1.idx = '{$idx}'";
 $row = $db->row($sql);
 if (!$row) {
     die('잘못된 접근입니다.');
@@ -37,7 +40,7 @@ echo "<table border='1'>";
 
 $rows = [
     '신청자구분' => printType($row['f_applicant_type']),
-    '대회구분'   => printValue($row['f_competition_idx']),
+    '대회구분'   => printValue($row['f_title']),
     '참가부문'   => printValue($row['f_part']),
     '종목분야'   => printValue($row['f_field']),
     '참가종목'   => printValue($row['f_event']),

--- a/Madmin/registration/reg_edu_view.php
+++ b/Madmin/registration/reg_edu_view.php
@@ -4,7 +4,10 @@ include $_SERVER['DOCUMENT_ROOT'] . "/Madmin/inc/top.php";
 $idx = isset($_GET['idx']) ? (int) $_GET['idx'] : 0;
 $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
 
-$sql = "SELECT * FROM df_site_edu_registration WHERE idx = '{$idx}'";
+$sql = "SELECT t1.*, b.subject
+        FROM df_site_edu_registration t1
+        LEFT JOIN df_site_bbs b ON t1.f_news_idx = b.idx
+        WHERE t1.idx = '{$idx}'";
 $row = $db->row($sql);
 if (!$row) {
     error('잘못된 접근입니다.', 'edu_list.php');
@@ -47,7 +50,7 @@ function printType($val)
                 </tr>
                 <tr>
                     <td style="width:200px;">교육구분</td>
-                    <td><?= printValue($row['f_news_idx']) ?></td>
+                    <td><?= printValue($row['subject']) ?></td>
                 </tr>
                 <tr>
                     <td style="width:200px;">이름/기관명</td>

--- a/Madmin/registration/reg_edu_view_excel.php
+++ b/Madmin/registration/reg_edu_view_excel.php
@@ -4,7 +4,10 @@ include "../../inc/util_lib.inc";
 
 $idx = isset($_GET['idx']) ? (int)$_GET['idx'] : 0;
 
-$sql = "SELECT * FROM df_site_edu_registration WHERE idx = '{$idx}'";
+$sql = "SELECT t1.*, b.subject
+        FROM df_site_edu_registration t1
+        LEFT JOIN df_site_bbs b ON t1.f_news_idx = b.idx
+        WHERE t1.idx = '{$idx}'";
 $row = $db->row($sql);
 if (!$row) {
     die('잘못된 접근입니다.');
@@ -37,7 +40,7 @@ echo "<table border='1'>";
 
 $rows = [
     '구분'           => printType($row['f_type']),
-    '교육구분'       => printValue($row['f_news_idx']),
+    '교육구분'       => printValue($row['subject']),
     '이름/기관명'    => printValue($row['f_user_name']),
     '영문이름/담당자' => printValue($row['f_user_name_en']),
     '성별'           => printValue($row['f_gender']),


### PR DESCRIPTION
## Summary
- join registration view queries with reference tables
- show schedule info, competition titles and education subjects instead of raw ids

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686242c5c6908322af14361096a02245