### PR TITLE
Fix schedule options display when category unselected

### DIFF
--- a/center/center_sub_apply.php
+++ b/center/center_sub_apply.php
@@ -837,11 +837,16 @@ unset($sc);
 
         scheduleSelect.innerHTML = '';
         if (schedulePlaceholder) scheduleSelect.appendChild(schedulePlaceholder);
-        scheduleOptions.forEach(opt => {
-            if (!selected || opt.dataset.category === selected || opt.dataset.category === '') {
-                scheduleSelect.appendChild(opt);
-            }
-        });
+        if (selected) {
+            scheduleOptions.forEach(opt => {
+                if (opt.dataset.category === selected || opt.dataset.category === '') {
+                    scheduleSelect.appendChild(opt);
+                }
+            });
+            scheduleSelect.disabled = false;
+        } else {
+            scheduleSelect.disabled = true;
+        }
         scheduleSelect.value = '';
     }
 

--- a/center/center_sub_apply_o.php
+++ b/center/center_sub_apply_o.php
@@ -825,11 +825,16 @@ unset($sc);
 
         scheduleSelect.innerHTML = '';
         if (schedulePlaceholder) scheduleSelect.appendChild(schedulePlaceholder);
-        scheduleOptions.forEach(opt => {
-            if (!selected || opt.dataset.category === selected || opt.dataset.category === '') {
-                scheduleSelect.appendChild(opt);
-            }
-        });
+        if (selected) {
+            scheduleOptions.forEach(opt => {
+                if (opt.dataset.category === selected || opt.dataset.category === '') {
+                    scheduleSelect.appendChild(opt);
+                }
+            });
+            scheduleSelect.disabled = false;
+        } else {
+            scheduleSelect.disabled = true;
+        }
         scheduleSelect.value = '';
     }
 


### PR DESCRIPTION
## Summary
- update schedule dropdown filter logic to hide options unless a category is chosen
- disable schedule select when no category is selected

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68625975f8e4832295c3ae6acc10c3eb