### PR TITLE
Update MyPage to show applicant status

### DIFF
--- a/Madmin/registration/reg_application_status_update.php
+++ b/Madmin/registration/reg_application_status_update.php
@@ -1,0 +1,23 @@
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/global.inc';
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/util_lib.inc';
+
+$idx = isset($_POST['idx']) ? (int) $_POST['idx'] : 0;
+$page = isset($_POST['page']) ? (int) $_POST['page'] : 1;
+$status = isset($_POST['f_applicant_status']) ? (int) $_POST['f_applicant_status'] : 1;
+
+if ($idx <= 0) {
+    error('잘못된 접근입니다.');
+    exit;
+}
+
+if (!in_array($status, [1, 2, 3])) {
+    $status = 1;
+}
+
+$db->query(
+    'UPDATE df_site_application_registration SET f_applicant_status=:st WHERE idx=:idx',
+    ['st' => $status, 'idx' => $idx]
+);
+
+complete('신청결과가 변경되었습니다.', "reg_application_view.php?idx={$idx}&page={$page}");

--- a/Madmin/registration/reg_application_view.php
+++ b/Madmin/registration/reg_application_view.php
@@ -156,6 +156,21 @@ $application_type_map = [
                     <td style="width:200px;">등록일</td>
                     <td><?= printValue($row['reg_date']) ?></td>
                 </tr>
+                <tr>
+                    <td style="width:200px;">신청결과</td>
+                    <td>
+                        <form method="post" action="reg_application_status_update.php" style="display:inline-block;">
+                            <input type="hidden" name="idx" value="<?= $idx ?>">
+                            <input type="hidden" name="page" value="<?= $page ?>">
+                            <select name="f_applicant_status" class="form-control" style="width:auto;display:inline-block;">
+                                <option value="1" <?= $row['f_applicant_status'] == 1 ? 'selected' : '' ?>>접수완료</option>
+                                <option value="2" <?= $row['f_applicant_status'] == 2 ? 'selected' : '' ?>>발급완료</option>
+                                <option value="3" <?= $row['f_applicant_status'] == 3 ? 'selected' : '' ?>>발급보류</option>
+                            </select>
+                            <button type="submit" class="btn btn-info btn-sm" style="margin-left:5px;">변경</button>
+                        </form>
+                    </td>
+                </tr>
             </table>
         </div>
     </div>

--- a/mypage/history.html
+++ b/mypage/history.html
@@ -8,7 +8,7 @@
         $user_id = $_SESSION['kbga_user_id'];
 
         $exam_rows = $db->query(
-            "SELECT r.idx, i.f_item_name, r.wdate as reg_date
+            "SELECT r.idx, r.f_applicant_status, i.f_item_name, r.wdate as reg_date
                FROM df_site_application_registration r
                LEFT JOIN df_site_qualification_item i ON r.f_item_idx = i.idx
               WHERE r.f_user_id = :uid AND r.f_application_type = 'exam'
@@ -17,7 +17,7 @@
         );
 
         $cert_rows = $db->query(
-            "SELECT r.idx, i.f_item_name, r.wdate as reg_date
+            "SELECT r.idx, r.f_applicant_status, i.f_item_name, r.wdate as reg_date
                FROM df_site_application_registration r
                LEFT JOIN df_site_qualification_item i ON r.f_item_idx = i.idx
               WHERE r.f_user_id = :uid AND r.f_application_type = 'cert'
@@ -33,6 +33,20 @@
               ORDER BY r.idx DESC",
             ['uid' => $user_id]
         );
+
+        function printStatus($val)
+        {
+            switch ((int) $val) {
+                case 1:
+                    return '접수완료';
+                case 2:
+                    return '발급완료';
+                case 3:
+                    return '발급보류';
+                default:
+                    return '';
+            }
+        }
 ?>
 
 <div id="container">
@@ -95,7 +109,7 @@
                                                                         <td align="center"><span>
                                                                                 <?= htmlspecialchars($row['f_item_name'], ENT_QUOTES) ?>
                                                                             </span></td>
-                                                                        <td align="center"><span>접수완료</span></td>
+                                                                        <td align="center"><span><?= printStatus($row['f_applicant_status']) ?></span></td>
                                                                         <td align="center"><span>
                                                                                 <?= date('Y.m.d', strtotime($row['reg_date'])) ?>
                                                                             </span></td>
@@ -145,7 +159,7 @@
                                                                         <td align="center"><span>
                                                                                 <?= htmlspecialchars($row['f_item_name'], ENT_QUOTES) ?>
                                                                             </span></td>
-                                                                        <td align="center"><span>접수완료</span></td>
+                                                                        <td align="center"><span><?= printStatus($row['f_applicant_status']) ?></span></td>
                                                                         <td align="center"><span>
                                                                                 <?= date('Y.m.d', strtotime($row['reg_date'])) ?>
                                                                             </span></td>


### PR DESCRIPTION
## Summary
- include `f_applicant_status` when loading application history
- display applicant status using new `printStatus()` helper

## Testing
- `php -l Madmin/registration/reg_application_status_update.php` *(fails: `php` not found)*
- `php -l mypage/history.html` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68633d2d0bdc832288eb6601939039b1