### PR TITLE
Add subject index reference for materials

### DIFF
--- a/Madmin/material/exec.php
+++ b/Madmin/material/exec.php
@@ -8,7 +8,7 @@ $page = isset($_REQUEST['page']) ? (int) $_REQUEST['page'] : 1;
 $category = $_REQUEST['f_category'] ?? '';
 $query_str = '&category=' . $category;
 
-$fields = ['f_category', 'f_subject', 'f_type', 'f_level', 'f_description', 'f_file', 'f_file_name'];
+$fields = ['f_category', 'f_subject_idx', 'f_subject', 'f_type', 'f_level', 'f_description', 'f_file', 'f_file_name'];
 
 switch ($mode) {
     case 'insert':
@@ -39,7 +39,7 @@ switch ($mode) {
         $sets = [];
         $params = [];
         // 텍스트 필드만 우선 업데이트 항목에 포함
-        foreach (['f_category', 'f_subject', 'f_type', 'f_level', 'f_description'] as $f) {
+        foreach (['f_category', 'f_subject_idx', 'f_subject', 'f_type', 'f_level', 'f_description'] as $f) {
             $sets[] = "$f=:$f";
             $params[$f] = $_POST[$f] ?? '';
         }

--- a/Madmin/material/material_input.php
+++ b/Madmin/material/material_input.php
@@ -19,6 +19,7 @@ $param = http_build_query($paramArr);
 
 $row = [
     'f_category' => $category,
+    'f_subject_idx' => 0,
     'f_subject' => '',
     'f_type' => '필기',
     'f_level' => '',
@@ -37,12 +38,12 @@ if ($idx) {
 }
 
 $subjects = $db->query(
-    "SELECT f_item_name FROM df_site_qualification_item WHERE f_category = :cat ORDER BY f_item_name ASC",
+    "SELECT idx, f_item_name FROM df_site_qualification_item WHERE f_category = :cat ORDER BY f_item_name ASC",
     ['cat' => $category]
 );
-$subject_names = array_column($subjects, 'f_item_name');
-if ($row['f_subject'] && !in_array($row['f_subject'], $subject_names)) {
-    $subjects[] = ['f_item_name' => $row['f_subject']];
+$subject_map = array_column($subjects, 'f_item_name', 'idx');
+if ($row['f_subject_idx'] && !isset($subject_map[$row['f_subject_idx']]) && $row['f_subject']) {
+    $subjects[] = ['idx' => $row['f_subject_idx'], 'f_item_name' => $row['f_subject']];
 }
 
 $category_map = [
@@ -80,17 +81,17 @@ $category_map = [
                         <td class="comALeft"><?= $category_map[$category] ?></td>
                     </tr>
                     <tr>
-                        <th><label for="f_subject">과목</label></th>
+                        <th><label for="f_subject_idx">과목</label></th>
                         <td class="comALeft">
-                            <select name="f_subject" id="f_subject" class="form-control" style="width:60%;">
+                            <select name="f_subject_idx" id="f_subject_idx" class="form-control" style="width:60%;">
                                 <option value="">과목 선택</option>
                                 <?php foreach ($subjects as $s): ?>
-                                    <option value="<?= htmlspecialchars($s['f_item_name']) ?>"
-                                        <?= $s['f_item_name'] == $row['f_subject'] ? 'selected' : '' ?>>
+                                    <option value="<?= $s['idx'] ?>" <?= (int)$s['idx'] === (int)$row['f_subject_idx'] ? 'selected' : '' ?>>
                                         <?= htmlspecialchars($s['f_item_name']) ?>
                                     </option>
                                 <?php endforeach; ?>
                             </select>
+                            <input type="hidden" name="f_subject" id="f_subject" value="<?= htmlspecialchars($row['f_subject']) ?>">
                         </td>
                     </tr>
                     <tr>
@@ -146,6 +147,21 @@ $category_map = [
         </div>
     </form>
 </div>
+<script>
+    (function(){
+        var select = document.getElementById('f_subject_idx');
+        var hidden = document.getElementById('f_subject');
+        function updateName(){
+            if(!select) return;
+            var txt = select.options[select.selectedIndex] ? select.options[select.selectedIndex].text : '';
+            if(hidden) hidden.value = txt;
+        }
+        if(select){
+            select.addEventListener('change', updateName);
+            updateName();
+        }
+    })();
+</script>
 </body>
 
 </html>

--- a/sql/create_df_site_material.sql
+++ b/sql/create_df_site_material.sql
@@ -1,6 +1,7 @@
 CREATE TABLE df_site_material (
     idx INT AUTO_INCREMENT PRIMARY KEY,
     f_category VARCHAR(20) NOT NULL,
+    f_subject_idx INT DEFAULT NULL,
     f_subject VARCHAR(255) NOT NULL,
     f_type VARCHAR(10) NOT NULL,
     f_level VARCHAR(50) NOT NULL,

--- a/sql/whole_database_table.sql
+++ b/sql/whole_database_table.sql
@@ -459,6 +459,7 @@ CREATE TABLE IF NOT EXISTS `df_site_main_slide` (
 CREATE TABLE IF NOT EXISTS `df_site_material` (
   `idx` int NOT NULL AUTO_INCREMENT,
   `f_category` varchar(20) NOT NULL,
+  `f_subject_idx` int DEFAULT NULL,
   `f_subject` varchar(255) NOT NULL,
   `f_type` varchar(10) NOT NULL,
   `f_level` varchar(50) NOT NULL,


### PR DESCRIPTION
## Summary
- 필기/실기 자료 테이블에 `f_subject_idx` 컬럼을 추가하여 과목의 IDX 값을 저장할 수 있도록 수정
- 관리 페이지(material_input.php)에서 과목 선택 시 IDX와 이름을 함께 전송하도록 변경
- 자료 등록/수정 처리(exec.php) 로직을 새로운 컬럼에 맞게 업데이트
- SQL 스키마(`create_df_site_material.sql`, `whole_database_table.sql`)에 컬럼 추가

## Testing
- `php -l` 실행 시 `bash: php: command not found` 오류 발생

------
https://chatgpt.com/codex/tasks/task_e_68634bd7020c832292620f8019a66fa9