### PR TITLE
동적 생년월일 선택 기능 추가

### DIFF
--- a/member/join_step02_group.html
+++ b/member/join_step02_group.html
@@ -467,6 +467,50 @@
 
         <script>
             document.addEventListener('DOMContentLoaded', function () {
+                var yearSel = document.getElementById('f_birth_date_1');
+                var monthSel = document.getElementById('f_birth_date_2');
+                var daySel = document.getElementById('f_birth_date_3');
+
+                if (yearSel && monthSel && daySel) {
+                    var currentYear = new Date().getFullYear();
+                    for (var y = currentYear; y >= currentYear - 120; y--) {
+                        var opt = document.createElement('option');
+                        opt.value = y;
+                        opt.textContent = y;
+                        yearSel.appendChild(opt);
+                    }
+
+                    for (var m = 1; m <= 12; m++) {
+                        var mv = (m < 10 ? '0' : '') + m;
+                        var optM = document.createElement('option');
+                        optM.value = mv;
+                        optM.textContent = mv;
+                        monthSel.appendChild(optM);
+                    }
+
+                    function updateDays() {
+                        var yv = parseInt(yearSel.value, 10);
+                        var mv = parseInt(monthSel.value, 10);
+                        daySel.innerHTML = '<option value="">선택</option>';
+                        if (!yv || !mv) return;
+                        var days = new Date(yv, mv, 0).getDate();
+                        for (var d = 1; d <= days; d++) {
+                            var dv = (d < 10 ? '0' : '') + d;
+                            var optD = document.createElement('option');
+                            optD.value = dv;
+                            optD.textContent = dv;
+                            daySel.appendChild(optD);
+                        }
+                    }
+
+                    yearSel.addEventListener('change', updateDays);
+                    monthSel.addEventListener('change', updateDays);
+                }
+            });
+        </script>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
                 new FormSubmitter('sign_up_frm');
             });
         </script>

--- a/member/join_step02_individual.html
+++ b/member/join_step02_individual.html
@@ -133,10 +133,9 @@
 																					<tbody>
 																						<tr>
 																							<td align="left" class="select_td">
-																								<select name="f_birth_date_1" id="f_birth_date_1" data-required="y" class="select">
-																									<option value="">선택</option>
-																									<option value="">2025</option>
-																								</select>
+                                        <select name="f_birth_date_1" id="f_birth_date_1" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																							</td>
 																							<td align="right" class="text_td">
 																								<span>
@@ -152,10 +151,9 @@
 																					<tbody>
 																						<tr>
 																							<td align="left" class="select_td">
-																								<select name="f_birth_date_2" id="f_birth_date_2" data-required="y" class="select">
-																									<option value="">선택</option>
-																									<option value="">01</option>
-																								</select>
+                                        <select name="f_birth_date_2" id="f_birth_date_2" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																							</td>
 																							<td align="right" class="text_td">
 																								<span>
@@ -171,10 +169,9 @@
 																					<tbody>
 																						<tr>
 																							<td align="left" class="select_td">
-																								<select name="f_birth_date_3" id="f_birth_date_3" data-required="y" class="select">
-																									<option value="">선택</option>
-																									<option value="">01</option>
-																								</select>
+                                        <select name="f_birth_date_3" id="f_birth_date_3" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																							</td>
 																							<td align="right" class="text_td">
 																								<span>
@@ -764,6 +761,50 @@
 				$(".email_address_input").val(val).attr("readonly",true);
 			}
 		}
+        </script>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                var yearSel = document.getElementById('f_birth_date_1');
+                var monthSel = document.getElementById('f_birth_date_2');
+                var daySel = document.getElementById('f_birth_date_3');
+
+                if (yearSel && monthSel && daySel) {
+                    var currentYear = new Date().getFullYear();
+                    for (var y = currentYear; y >= currentYear - 120; y--) {
+                        var opt = document.createElement('option');
+                        opt.value = y;
+                        opt.textContent = y;
+                        yearSel.appendChild(opt);
+                    }
+
+                    for (var m = 1; m <= 12; m++) {
+                        var mv = (m < 10 ? '0' : '') + m;
+                        var optM = document.createElement('option');
+                        optM.value = mv;
+                        optM.textContent = mv;
+                        monthSel.appendChild(optM);
+                    }
+
+                    function updateDays() {
+                        var yv = parseInt(yearSel.value, 10);
+                        var mv = parseInt(monthSel.value, 10);
+                        daySel.innerHTML = '<option value="">선택</option>';
+                        if (!yv || !mv) return;
+                        var days = new Date(yv, mv, 0).getDate();
+                        for (var d = 1; d <= days; d++) {
+                            var dv = (d < 10 ? '0' : '') + d;
+                            var optD = document.createElement('option');
+                            optD.value = dv;
+                            optD.textContent = dv;
+                            daySel.appendChild(optD);
+                        }
+                    }
+
+                    yearSel.addEventListener('change', updateDays);
+                    monthSel.addEventListener('change', updateDays);
+                }
+            });
         </script>
 
         <script>


### PR DESCRIPTION
## Summary
- 회원가입(개인, 단체) 페이지의 생년월일 입력을 동적 선택 방식으로 개선
- 현재 년도 기준 120년 전까지의 년도와 월/일 자동 생성
- 년도와 월 변경 시 일 옵션을 자동으로 갱신

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68636b68a390832295e9a3c30d93b9a4