### PR TITLE
회원정보 수정 페이지 생년월일 선택 개선

### DIFF
--- a/member/join_step02_group.html
+++ b/member/join_step02_group.html
@@ -467,6 +467,50 @@
 
         <script>
             document.addEventListener('DOMContentLoaded', function () {
+                var yearSel = document.getElementById('f_birth_date_1');
+                var monthSel = document.getElementById('f_birth_date_2');
+                var daySel = document.getElementById('f_birth_date_3');
+
+                if (yearSel && monthSel && daySel) {
+                    var currentYear = new Date().getFullYear();
+                    for (var y = currentYear; y >= currentYear - 120; y--) {
+                        var opt = document.createElement('option');
+                        opt.value = y;
+                        opt.textContent = y;
+                        yearSel.appendChild(opt);
+                    }
+
+                    for (var m = 1; m <= 12; m++) {
+                        var mv = (m < 10 ? '0' : '') + m;
+                        var optM = document.createElement('option');
+                        optM.value = mv;
+                        optM.textContent = mv;
+                        monthSel.appendChild(optM);
+                    }
+
+                    function updateDays() {
+                        var yv = parseInt(yearSel.value, 10);
+                        var mv = parseInt(monthSel.value, 10);
+                        daySel.innerHTML = '<option value="">선택</option>';
+                        if (!yv || !mv) return;
+                        var days = new Date(yv, mv, 0).getDate();
+                        for (var d = 1; d <= days; d++) {
+                            var dv = (d < 10 ? '0' : '') + d;
+                            var optD = document.createElement('option');
+                            optD.value = dv;
+                            optD.textContent = dv;
+                            daySel.appendChild(optD);
+                        }
+                    }
+
+                    yearSel.addEventListener('change', updateDays);
+                    monthSel.addEventListener('change', updateDays);
+                }
+            });
+        </script>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
                 new FormSubmitter('sign_up_frm');
             });
         </script>

--- a/member/join_step02_individual.html
+++ b/member/join_step02_individual.html
@@ -133,10 +133,9 @@
 																					<tbody>
 																						<tr>
 																							<td align="left" class="select_td">
-																								<select name="f_birth_date_1" id="f_birth_date_1" data-required="y" class="select">
-																									<option value="">선택</option>
-																									<option value="">2025</option>
-																								</select>
+                                        <select name="f_birth_date_1" id="f_birth_date_1" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																							</td>
 																							<td align="right" class="text_td">
 																								<span>
@@ -152,10 +151,9 @@
 																					<tbody>
 																						<tr>
 																							<td align="left" class="select_td">
-																								<select name="f_birth_date_2" id="f_birth_date_2" data-required="y" class="select">
-																									<option value="">선택</option>
-																									<option value="">01</option>
-																								</select>
+                                        <select name="f_birth_date_2" id="f_birth_date_2" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																							</td>
 																							<td align="right" class="text_td">
 																								<span>
@@ -171,10 +169,9 @@
 																					<tbody>
 																						<tr>
 																							<td align="left" class="select_td">
-																								<select name="f_birth_date_3" id="f_birth_date_3" data-required="y" class="select">
-																									<option value="">선택</option>
-																									<option value="">01</option>
-																								</select>
+                                        <select name="f_birth_date_3" id="f_birth_date_3" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																							</td>
 																							<td align="right" class="text_td">
 																								<span>
@@ -764,6 +761,50 @@
 				$(".email_address_input").val(val).attr("readonly",true);
 			}
 		}
+        </script>
+
+        <script>
+            document.addEventListener('DOMContentLoaded', function () {
+                var yearSel = document.getElementById('f_birth_date_1');
+                var monthSel = document.getElementById('f_birth_date_2');
+                var daySel = document.getElementById('f_birth_date_3');
+
+                if (yearSel && monthSel && daySel) {
+                    var currentYear = new Date().getFullYear();
+                    for (var y = currentYear; y >= currentYear - 120; y--) {
+                        var opt = document.createElement('option');
+                        opt.value = y;
+                        opt.textContent = y;
+                        yearSel.appendChild(opt);
+                    }
+
+                    for (var m = 1; m <= 12; m++) {
+                        var mv = (m < 10 ? '0' : '') + m;
+                        var optM = document.createElement('option');
+                        optM.value = mv;
+                        optM.textContent = mv;
+                        monthSel.appendChild(optM);
+                    }
+
+                    function updateDays() {
+                        var yv = parseInt(yearSel.value, 10);
+                        var mv = parseInt(monthSel.value, 10);
+                        daySel.innerHTML = '<option value="">선택</option>';
+                        if (!yv || !mv) return;
+                        var days = new Date(yv, mv, 0).getDate();
+                        for (var d = 1; d <= days; d++) {
+                            var dv = (d < 10 ? '0' : '') + d;
+                            var optD = document.createElement('option');
+                            optD.value = dv;
+                            optD.textContent = dv;
+                            daySel.appendChild(optD);
+                        }
+                    }
+
+                    yearSel.addEventListener('change', updateDays);
+                    monthSel.addEventListener('change', updateDays);
+                }
+            });
         </script>
 
         <script>

--- a/mypage/modify.html
+++ b/mypage/modify.html
@@ -124,10 +124,9 @@ list($c1, $c2, $c3) = explode('-', $row['f_contact_phone']);
 																									<tbody>
 																										<tr>
 																											<td align="left" class="select_td">
-																												<select name="f_birth_date_1" id="f_birth_date_1" data-required="y" class="select">
-																													<option value="">선택</option>
-																													<option value="">2025</option>
-																												</select>
+                                        <select name="f_birth_date_1" id="f_birth_date_1" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																											</td>
 																											<td align="right" class="text_td">
 																												<span>
@@ -143,10 +142,9 @@ list($c1, $c2, $c3) = explode('-', $row['f_contact_phone']);
 																									<tbody>
 																										<tr>
 																											<td align="left" class="select_td">
-																												<select name="f_birth_date_2" id="f_birth_date_2" data-required="y" class="select">
-																													<option value="">선택</option>
-																													<option value="">01</option>
-																												</select>
+                                        <select name="f_birth_date_2" id="f_birth_date_2" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																											</td>
 																											<td align="right" class="text_td">
 																												<span>
@@ -162,10 +160,9 @@ list($c1, $c2, $c3) = explode('-', $row['f_contact_phone']);
 																									<tbody>
 																										<tr>
 																											<td align="left" class="select_td">
-																												<select name="f_birth_date_3" id="f_birth_date_3" data-required="y" class="select">
-																													<option value="">선택</option>
-																													<option value="">01</option>
-																												</select>
+                                        <select name="f_birth_date_3" id="f_birth_date_3" data-required="y" class="select">
+                                            <option value="">선택</option>
+                                        </select>
 																											</td>
 																											<td align="right" class="text_td">
 																												<span>
@@ -1498,6 +1495,7 @@ list($c1, $c2, $c3) = explode('-', $row['f_contact_phone']);
         }).open();
     }
 </script>
+
 <script type="text/javascript" language="javascript">
     // 숫자만 입력
     function onlyNumber(obj) {
@@ -1506,15 +1504,74 @@ list($c1, $c2, $c3) = explode('-', $row['f_contact_phone']);
         });
     }
 
-	// 이메일
-	function email_address_select(val){
-		var state = $(".email_select option:selected").val();
-		if ( state == "" ) {
-			$(".email_address_input").val("").attr("readonly",false).focus();
-		}else{
-			$(".email_address_input").val(val).attr("readonly",true);
-		}
-	}
+        // 이메일
+        function email_address_select(val){
+                var state = $(".email_select option:selected").val();
+                if ( state == "" ) {
+                        $(".email_address_input").val("").attr("readonly",false).focus();
+                }else{
+                        $(".email_address_input").val(val).attr("readonly",true);
+                }
+        }
+</script>
+
+<script>
+    document.addEventListener('DOMContentLoaded', function () {
+        var yearSel = document.getElementById('f_birth_date_1');
+        var monthSel = document.getElementById('f_birth_date_2');
+        var daySel = document.getElementById('f_birth_date_3');
+
+        if (yearSel && monthSel && daySel) {
+            var currentYear = new Date().getFullYear();
+            for (var y = currentYear; y >= currentYear - 120; y--) {
+                var opt = document.createElement('option');
+                opt.value = y;
+                opt.textContent = y;
+                yearSel.appendChild(opt);
+            }
+
+            for (var m = 1; m <= 12; m++) {
+                var mv = (m < 10 ? '0' : '') + m;
+                var optM = document.createElement('option');
+                optM.value = mv;
+                optM.textContent = mv;
+                monthSel.appendChild(optM);
+            }
+
+            function updateDays() {
+                var yv = parseInt(yearSel.value, 10);
+                var mv = parseInt(monthSel.value, 10);
+                daySel.innerHTML = '<option value="">선택</option>';
+                if (!yv || !mv) return;
+                var days = new Date(yv, mv, 0).getDate();
+                for (var d = 1; d <= days; d++) {
+                    var dv = (d < 10 ? '0' : '') + d;
+                    var optD = document.createElement('option');
+                    optD.value = dv;
+                    optD.textContent = dv;
+                    daySel.appendChild(optD);
+                }
+            }
+
+            var selYear = '<?= htmlspecialchars($y, ENT_QUOTES) ?>';
+            var selMonth = ('0' + '<?= htmlspecialchars($m, ENT_QUOTES) ?>').slice(-2);
+            var selDay = ('0' + '<?= htmlspecialchars($d, ENT_QUOTES) ?>').slice(-2);
+
+            yearSel.value = selYear;
+            monthSel.value = selMonth;
+            updateDays();
+            daySel.value = selDay;
+
+            yearSel.addEventListener('change', function () {
+                updateDays();
+                daySel.value = '';
+            });
+            monthSel.addEventListener('change', function () {
+                updateDays();
+                daySel.value = '';
+            });
+        }
+    });
 </script>
 
 <script src="/js/form-controller.js"></script>


### PR DESCRIPTION
## Summary
- 수정 페이지의 연도/월/일 선택을 동적 방식으로 변경
- 기존 사용자 정보를 자동으로 선택하도록 스크립트 추가

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68636b68a390832295e9a3c30d93b9a4