### PR TITLE
Remove unused phone verification links

### DIFF
--- a/member/find_id.html
+++ b/member/find_id.html
@@ -150,92 +150,94 @@
 													</div>
 												</div>
 											</li>
-											<li class="tel_li">
-												<div class="list_div">
-													<div class="title_con">
-														<span>
-															휴대전화번호 <span class="dot">*</span>
-														</span>
-													</div>
+<!-- 휴대폰 인증 기능 보류로 인해 입력 폼 숨김 처리
+                                                                  <li class="tel_li" style="display:none;">
+                                                                       <div class="list_div">
+                                                                               <div class="title_con">
+                                                                               <span>
+                                                                               휴대전화번호 <span class="dot">*</span>
+                                                                               </span>
+                                                                               </div>
 
-													<div class="info_con">
-														<div class="tel_con">
-															<table cellpadding="0" cellspacing="0">
-																<tbody>
-																	<tr>
-																		<td align="left" class="input_td">
-																			<input type="tel" name="" maxlength="3" class="input" onkeydown="onlyNumber(this);" />
-																		</td>
-																		<td align="center" class="text_td">
-																			-
-																		</td>
-																		<td align="left" class="input_td">
-																			<input type="tel" name="" maxlength="4" class="input" onkeydown="onlyNumber(this);" />
-																		</td>
-																		<td align="center" class="text_td">
-																			-
-																		</td>
-																		<td align="left" class="input_td">
-																			<input type="tel" name="" maxlength="4" class="input" onkeydown="onlyNumber(this);" />
-																		</td>
-																		<td align="left" class="blank_td">
-																			&nbsp;
-																		</td>
-																		<td align="left" class="btn_td">
-																			<a href="javascript:code_tel();" class="a_btn a_btn01">
-																				인증요청
-																			</a>
-																		</td>
-																	</tr>
-																</tbody>
-															</table>
-														</div>
+                                                                               <div class="info_con">
+                                                                               <div class="tel_con">
+                                                                               <table cellpadding="0" cellspacing="0">
+                                                                               <tbody>
+                                                                               <tr>
+                                                                               <td align="left" class="input_td">
+                                                                               <input type="tel" name="" maxlength="3" class="input" onkeydown="onlyNumber(this);" />
+                                                                               </td>
+                                                                               <td align="center" class="text_td">
+                                                                               -
+                                                                               </td>
+                                                                               <td align="left" class="input_td">
+                                                                               <input type="tel" name="" maxlength="4" class="input" onkeydown="onlyNumber(this);" />
+                                                                               </td>
+                                                                               <td align="center" class="text_td">
+                                                                               -
+                                                                               </td>
+                                                                               <td align="left" class="input_td">
+                                                                               <input type="tel" name="" maxlength="4" class="input" onkeydown="onlyNumber(this);" />
+                                                                               </td>
+                                                                               <td align="left" class="blank_td">
+                                                                               &nbsp;
+                                                                               </td>
+                                                                               <td align="left" class="btn_td">
+                                                                               <a href="javascript:void(0);" class="a_btn a_btn01">
+                                                                               인증요청
+                                                                               </a>
+                                                                               </td>
+                                                                               </tr>
+                                                                               </tbody>
+                                                                               </table>
+                                                                               </div>
 
-														<div class="btn_con m_con">
-															<a href="javascript:code_tel();" class="a_btn a_btn01">
-																인증요청
-															</a>
-														</div>
-													</div>
-												</div>
-											</li>
-											<li class="tel_li code_li">
-												<div class="list_div">
-													<div class="title_con">
-														<span>
-															인증번호 <span class="dot">*</span>
-														</span>
-													</div>
+                                                                               <div class="btn_con m_con">
+                                                                               <a href="javascript:void(0);" class="a_btn a_btn01">
+                                                                               인증요청
+                                                                               </a>
+                                                                               </div>
+                                                                               </div>
+                                                                       </div>
+                                                                  </li>
+                                                                  <li class="tel_li code_li" style="display:none;">
+                                                                       <div class="list_div">
+                                                                               <div class="title_con">
+                                                                               <span>
+                                                                               인증번호 <span class="dot">*</span>
+                                                                               </span>
+                                                                               </div>
 
-													<div class="info_con">
-														<div class="code_con">
-															<table cellpadding="0" cellspacing="0">
-																<tbody>
-																	<tr>
-																		<td align="left" class="input_td">
-                                                                               <input type="tel" id="find_id_code" name="code" maxlength="6" placeholder="인증번호을 적어주세요." class="input" onkeydown="onlyNumber(this);" />
-																		</td>
-																		<td align="left" class="blank_td">
-																			&nbsp;
-																		</td>
-																		<td align="left" class="btn_td">
-																			<a href="#" class="a_btn a_btn02">
-																				인증확인
-																			</a>
-																		</td>
-																	</tr>
-																</tbody>
-															</table>
-														</div>
+                                                                               <div class="info_con">
+                                                                               <div class="code_con">
+                                                                               <table cellpadding="0" cellspacing="0">
+                                                                               <tbody>
+                                                                               <tr>
+                                                                               <td align="left" class="input_td">
+       <input type="tel" id="find_id_code" name="code" maxlength="6" placeholder="인증번호을 적어주세요." class="input" onkeydown="onlyNumber(this);" />
+                                                                               </td>
+                                                                               <td align="left" class="blank_td">
+                                                                               &nbsp;
+                                                                               </td>
+                                                                               <td align="left" class="btn_td">
+                                                                               <a href="#" class="a_btn a_btn02">
+                                                                               인증확인
+                                                                               </a>
+                                                                               </td>
+                                                                               </tr>
+                                                                               </tbody>
+                                                                               </table>
+                                                                               </div>
 
-														<div class="btn_con m_con">
-															<a href="#" class="a_btn a_btn02">
-																인증확인
-															</a>
-														</div>
-													</div>
-												</div>
-											</li>
+                                                                               <div class="btn_con m_con">
+                                                                               <a href="#" class="a_btn a_btn02">
+                                                                               인증확인
+                                                                               </a>
+                                                                               </div>
+                                                                               </div>
+                                                                       </div>
+                                                                  </li>
+-->
 											<li class="email_li">
 												<div class="list_div">
 													<div class="title_con">

--- a/member/find_pw.html
+++ b/member/find_pw.html
@@ -163,6 +163,7 @@
 													</div>
 												</div>
 											</li>
+<!-- 휴대폰 인증 기능 보류로 인해 입력 폼 숨김 처리
 											<li class="tel_li">
 												<div class="list_div">
 													<div class="title_con">
@@ -195,7 +196,7 @@
 																			&nbsp;
 																		</td>
 																		<td align="left" class="btn_td">
-																			<a href="javascript:code_tel();" class="a_btn a_btn01">
+																			<a href="javascript:void(0);" class="a_btn a_btn01">
 																				인증요청
 																			</a>
 																		</td>
@@ -236,6 +237,7 @@
 														</div>
 													</div>
 												</div>
+-->
 											</li>
 											<li class="email_li">
 												<div class="list_div">


### PR DESCRIPTION
## Summary
- disable unused phone verification links in member pages
- hide phone verification input sections

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6864d27b6ee48322b3f931e58a6d6da5