### PR TITLE
Implement ID recovery email verification

### DIFF
--- a/js/find_id.js
+++ b/js/find_id.js
@@ -1,0 +1,56 @@
+$(document).ready(function(){
+    var verified = false;
+    $('#send_code_btn').on('click', function(e){
+        e.preventDefault();
+        if(!$('#find_email').val().trim()){
+            alert('이메일을 입력해 주세요.');
+            $('#find_email').focus();
+            return;
+        }
+        var fd = new FormData();
+        fd.append('mode','send_code_id');
+        fd.append('email',$('#find_email').val().trim());
+        fetch('/controller/account_recovery.php',{method:'POST',body:fd})
+            .then(r=>r.json())
+            .then(function(res){
+                alert(res.msg);
+                if(res.result==='ok'){
+                    $('.email_li.code_li').show();
+                    $('#send_code_btn').text('재발송');
+                }
+            })
+            .catch(function(){
+                alert('요청 중 오류가 발생했습니다.');
+            });
+    });
+
+    $('#verify_code_btn').on('click', function(e){
+        e.preventDefault();
+        if(!$('#find_email_code').val().trim()){
+            alert('인증번호를 입력해 주세요.');
+            $('#find_email_code').focus();
+            return;
+        }
+        var fd = new FormData();
+        fd.append('mode','verify_code_id');
+        fd.append('code',$('#find_email_code').val().trim());
+        fetch('/controller/account_recovery.php',{method:'POST',body:fd})
+            .then(r=>r.json())
+            .then(function(res){
+                alert(res.msg);
+                if(res.result==='ok'){
+                    verified = true;
+                }
+            })
+            .catch(function(){
+                alert('요청 중 오류가 발생했습니다.');
+            });
+    });
+
+    $('#btn_next').on('click', function(e){
+        if(!verified){
+            e.preventDefault();
+            alert('인증을 완료해 주세요.');
+        }
+    });
+});

--- a/member/find_id.html
+++ b/member/find_id.html
@@ -3,10 +3,12 @@
 	$sMenu = "06-3";
 	$ssMenu = "06-3-1";
 
-	include $_SERVER['DOCUMENT_ROOT'].'/include/header.html'; 
+        include $_SERVER['DOCUMENT_ROOT'].'/include/header.html';
 ?>
 
-	<div id="container">
+    <script src="/js/find_id.js"></script>
+
+        <div id="container">
 		<div id="sub_con">
 			<?php
 				include $_SERVER['DOCUMENT_ROOT'].'/include/sub_banner.html'; 
@@ -212,13 +214,13 @@
 																<tbody>
 																	<tr>
 																		<td align="left" class="input_td">
-																			<input type="tel" name="" maxlength="" placeholder="인증번호을 적어주세요." class="input" onkeydown="onlyNumber(this);" />
+                                                                               <input type="tel" name="code" id="find_email_code" maxlength="" placeholder="인증번호을 적어주세요." class="input" onkeydown="onlyNumber(this);" />
 																		</td>
 																		<td align="left" class="blank_td">
 																			&nbsp;
 																		</td>
 																		<td align="left" class="btn_td">
-																			<a href="#" class="a_btn a_btn02">
+                                                                               <a href="#" class="a_btn a_btn02" id="verify_code_btn">
 																				인증확인
 																			</a>
 																		</td>
@@ -249,13 +251,13 @@
 																<tbody>
 																	<tr>
 																		<td align="left" class="input_td">
-																			<input type="text" name="" placeholder="이메일을 적어주세요." class="input" />
+                                                                               <input type="text" name="email" id="find_email" placeholder="이메일을 적어주세요." class="input" />
 																		</td>
 																		<td align="left" class="blank_td">
 																			&nbsp;
 																		</td>
 																		<td align="left" class="btn_td">
-																			<a href="javascript:code_email();" class="a_btn a_btn01">
+                                                                               <a href="javascript:code_email();" class="a_btn a_btn01" id="send_code_btn">
 																				인증요청
 																			</a>
 																		</td>
@@ -320,7 +322,7 @@
 								취소
 							</a>
 							
-							<a href="/member/find_id_end.html" class="a_btn a_btn02">
+                                                        <a href="/member/find_id_end.html" class="a_btn a_btn02" id="btn_next">
 								다음
 							</a>
 						</div>

--- a/member/find_id_end.html
+++ b/member/find_id_end.html
@@ -3,7 +3,14 @@
 	$sMenu = "06-3";
 	$ssMenu = "06-3-1";
 
-	include $_SERVER['DOCUMENT_ROOT'].'/include/header.html'; 
+        include $_SERVER['DOCUMENT_ROOT'].'/include/header.html';
+
+        if(empty($_SESSION['find_id_verified']) || empty($_SESSION['find_id']['user_id'])){
+            echo "<script>alert('잘못된 접근입니다.');location.href='/member/find_id.html';</script>";
+            exit;
+        }
+        $find_user_id = $_SESSION['find_id']['user_id'];
+        unset($_SESSION['find_id'], $_SESSION['find_id_verified']);
 ?>
 
 	<div id="container">
@@ -26,9 +33,9 @@
 							<div class="id_con">
 								<img src="/img/member/find_id_end_icon.svg" alt="아이콘" class="fx" />
 
-								<span>
-									sssyck123
-								</span>
+                                                                <span>
+                                                                        <?=htmlspecialchars($find_user_id,ENT_QUOTES,'UTF-8')?>
+                                                                </span>
 							</div>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary
- add `js/find_id.js` for email verification workflow
- inject script and IDs into `find_id.html`
- display verified user id via session in `find_id_end.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864eea08cc08322b0925142a06da035