### PR TITLE
Fix file upload handling for group applications

### DIFF
--- a/controller/applicate_controller_o.php
+++ b/controller/applicate_controller_o.php
@@ -41,6 +41,29 @@ function upload_file(array $file): array
     return ['saved' => $new, 'original' => $orig];
 }
 
+function upload_files(array $files): array
+{
+    $saved = [];
+    if (!isset($files['name']) || !is_array($files['name'])) {
+        return $saved;
+    }
+    $cnt = count($files['name']);
+    for ($i = 0; $i < $cnt; $i++) {
+        if (empty($files['name'][$i])) {
+            continue;
+        }
+        $fileInfo = [
+            'name' => $files['name'][$i],
+            'tmp_name' => $files['tmp_name'][$i] ?? '',
+            'size' => $files['size'][$i] ?? 0,
+            'error' => $files['error'][$i] ?? UPLOAD_ERR_NO_FILE,
+        ];
+        $info = upload_file($fileInfo);
+        $saved[] = $info['saved'];
+    }
+    return $saved;
+}
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     return_json(['result' => 'error', 'msg' => '잘못된 요청입니다.']);
 }
@@ -100,9 +123,11 @@ if (empty($filtered['agree_privacy'])) {
 $payment_cat = implode(',', $filtered['f_payment_category']);
 
 $uploadName = null;
-if (!empty($_FILES['f_issue_file']['name'])) {
-    $info = upload_file($_FILES['f_issue_file']);
-    $uploadName = $info['saved'];
+if (!empty($_FILES['upfile']['name'])) {
+    $uploaded = upload_files($_FILES['upfile']);
+    if ($uploaded) {
+        $uploadName = implode(',', $uploaded);
+    }
 }
 
 $f_user_id = isset($_SESSION['kbga_user_id']) && $_SESSION['kbga_user_id'] != '' ? $_SESSION['kbga_user_id'] : '';


### PR DESCRIPTION
## Summary
- adjust applicate_controller_o.php to support multiple file uploads as `upfile[]`
- store comma-separated uploaded file names in the existing `f_issue_file` field

## Testing
- `php` 명령이 없어 스크립트 검증 불가

------
https://chatgpt.com/codex/tasks/task_e_686b47175b548322ae7a159561ecea57