### PR TITLE
Add competition option tables and linking

### DIFF
--- a/Madmin/competition/competition_input.php
+++ b/Madmin/competition/competition_input.php
@@ -15,6 +15,9 @@ if ($idx) {
         echo "<script>alert('잘못된 접근입니다.');location.href='competition_list.php?{$param}';</script>";
         exit;
     }
+    $parts  = $db->query("SELECT f_part FROM df_site_competition_part WHERE competition_idx=:idx ORDER BY idx ASC", ['idx'=>$idx]);
+    $fields = $db->query("SELECT f_field FROM df_site_competition_field WHERE competition_idx=:idx ORDER BY idx ASC", ['idx'=>$idx]);
+    $events = $db->query("SELECT f_event FROM df_site_competition_event WHERE competition_idx=:idx ORDER BY idx ASC", ['idx'=>$idx]);
 } else {
     $mode = 'insert';
     $row = [
@@ -26,6 +29,7 @@ if ($idx) {
         'f_detail'=>'',
         'f_image'=>''
     ];
+    $parts = $fields = $events = [];
 }
 ?>
 <script language="JavaScript">
@@ -117,6 +121,86 @@ function deleteImage(idx, field){
                 </table>
             </div>
         </div>
+        <div class="box comMTop20" style="width:978px;">
+            <div class="panel">
+                <div class="title">
+                    <i class="fa fa-list"></i>
+                    <span>참가부문</span>
+                    <button class="btn btn-success btn-xs comMLeft15 btnAddPart" type="button">항목추가</button>
+                </div>
+                <table id="tablePart" class="table orderInfo" cellpadding="0" cellspacing="0">
+                    <col width="85%"><col width="15%">
+                    <tbody>
+                        <?php if($mode=='insert' && empty($parts)): ?>
+                        <tr>
+                            <td class="comALeft"><input type="text" name="parts[]" class="form-control" style="width:60%;"></td>
+                            <td><button class="btn btn-warning btn-xs btnDelPart" type="button">삭제</button></td>
+                        </tr>
+                        <?php endif; ?>
+                        <?php foreach ($parts as $p): ?>
+                        <tr>
+                            <td class="comALeft"><input type="text" name="parts[]" value="<?= htmlspecialchars($p['f_part'], ENT_QUOTES) ?>" class="form-control" style="width:60%;"></td>
+                            <td><button class="btn btn-warning btn-xs btnDelPart" type="button">삭제</button></td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="box comMTop20" style="width:978px;">
+            <div class="panel">
+                <div class="title">
+                    <i class="fa fa-list"></i>
+                    <span>종목분야</span>
+                    <button class="btn btn-success btn-xs comMLeft15 btnAddField" type="button">항목추가</button>
+                </div>
+                <table id="tableField" class="table orderInfo" cellpadding="0" cellspacing="0">
+                    <col width="85%"><col width="15%">
+                    <tbody>
+                        <?php if($mode=='insert' && empty($fields)): ?>
+                        <tr>
+                            <td class="comALeft"><input type="text" name="fields[]" class="form-control" style="width:60%;"></td>
+                            <td><button class="btn btn-warning btn-xs btnDelField" type="button">삭제</button></td>
+                        </tr>
+                        <?php endif; ?>
+                        <?php foreach ($fields as $f): ?>
+                        <tr>
+                            <td class="comALeft"><input type="text" name="fields[]" value="<?= htmlspecialchars($f['f_field'], ENT_QUOTES) ?>" class="form-control" style="width:60%;"></td>
+                            <td><button class="btn btn-warning btn-xs btnDelField" type="button">삭제</button></td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+
+        <div class="box comMTop20" style="width:978px;">
+            <div class="panel">
+                <div class="title">
+                    <i class="fa fa-list"></i>
+                    <span>참가종목</span>
+                    <button class="btn btn-success btn-xs comMLeft15 btnAddEvent" type="button">항목추가</button>
+                </div>
+                <table id="tableEvent" class="table orderInfo" cellpadding="0" cellspacing="0">
+                    <col width="85%"><col width="15%">
+                    <tbody>
+                        <?php if($mode=='insert' && empty($events)): ?>
+                        <tr>
+                            <td class="comALeft"><input type="text" name="events[]" class="form-control" style="width:60%;"></td>
+                            <td><button class="btn btn-warning btn-xs btnDelEvent" type="button">삭제</button></td>
+                        </tr>
+                        <?php endif; ?>
+                        <?php foreach ($events as $e): ?>
+                        <tr>
+                            <td class="comALeft"><input type="text" name="events[]" value="<?= htmlspecialchars($e['f_event'], ENT_QUOTES) ?>" class="form-control" style="width:60%;"></td>
+                            <td><button class="btn btn-warning btn-xs btnDelEvent" type="button">삭제</button></td>
+                        </tr>
+                        <?php endforeach; ?>
+                    </tbody>
+                </table>
+            </div>
+        </div>
         <div class="box comMTop10 comMBottom20" style="width:978px;">
             <div class="comPTop10 comPBottom10">
                 <div class="comFLeft comACenter" style="width:10%;">
@@ -133,5 +217,19 @@ function deleteImage(idx, field){
         </div>
     </form>
 </div>
+<script>
+$(document).on('click','.btnAddPart',function(){
+    $('#tablePart tbody').append('<tr><td class="comALeft"><input type="text" name="parts[]" class="form-control" style="width:60%;"></td><td><button class="btn btn-warning btn-xs btnDelPart" type="button">삭제</button></td></tr>');
+});
+$(document).on('click','.btnDelPart',function(){ $(this).closest('tr').remove(); });
+$(document).on('click','.btnAddField',function(){
+    $('#tableField tbody').append('<tr><td class="comALeft"><input type="text" name="fields[]" class="form-control" style="width:60%;"></td><td><button class="btn btn-warning btn-xs btnDelField" type="button">삭제</button></td></tr>');
+});
+$(document).on('click','.btnDelField',function(){ $(this).closest('tr').remove(); });
+$(document).on('click','.btnAddEvent',function(){
+    $('#tableEvent tbody').append('<tr><td class="comALeft"><input type="text" name="events[]" class="form-control" style="width:60%;"></td><td><button class="btn btn-warning btn-xs btnDelEvent" type="button">삭제</button></td></tr>');
+});
+$(document).on('click','.btnDelEvent',function(){ $(this).closest('tr').remove(); });
+</script>
 </body>
 </html>

--- a/Madmin/exec/exec.php
+++ b/Madmin/exec/exec.php
@@ -77,7 +77,10 @@ switch ($mode) {
             $fields[] = "{$col}='" . addslashes($filename) . "'";
         }
         foreach ($_POST as $key => $val) {
-            if (in_array($key, ['mode', 'table', 'page', 'usage', 'region', 'idx', 'selidx', 'dir', 'field', 'keyword', 'old_idx']))
+            if (
+                in_array($key, ['mode', 'table', 'page', 'usage', 'region', 'idx', 'selidx', 'dir', 'field', 'keyword', 'old_idx']) ||
+                is_array($val)
+            )
                 continue;
             $fields[] = "{$key}='" . addslashes($val) . "'";
         }
@@ -87,7 +90,29 @@ switch ($mode) {
 
         $bbsidx = $db->lastInsertId();
 
-        if ($table == 'sigong') {
+        if ($table == 'competition') {
+            $partArr  = isset($_POST['parts']) && is_array($_POST['parts']) ? $_POST['parts'] : [];
+            $fieldArr = isset($_POST['fields']) && is_array($_POST['fields']) ? $_POST['fields'] : [];
+            $eventArr = isset($_POST['events']) && is_array($_POST['events']) ? $_POST['events'] : [];
+            foreach ($partArr as $v) {
+                $v = trim($v);
+                if ($v !== '') {
+                    $db->query("INSERT INTO df_site_competition_part SET competition_idx=:c, f_part=:v", ['c'=>$bbsidx,'v'=>$v]);
+                }
+            }
+            foreach ($fieldArr as $v) {
+                $v = trim($v);
+                if ($v !== '') {
+                    $db->query("INSERT INTO df_site_competition_field SET competition_idx=:c, f_field=:v", ['c'=>$bbsidx,'v'=>$v]);
+                }
+            }
+            foreach ($eventArr as $v) {
+                $v = trim($v);
+                if ($v !== '') {
+                    $db->query("INSERT INTO df_site_competition_event SET competition_idx=:c, f_event=:v", ['c'=>$bbsidx,'v'=>$v]);
+                }
+            }
+        } elseif ($table == 'sigong') {
             // 3. upfile[] 업로드 처리
             $upload_dir = $_SERVER['DOCUMENT_ROOT'] . "/userfiles/" . $table;
 
@@ -127,7 +152,10 @@ switch ($mode) {
         }
         $fields = [];
         foreach ($_POST as $key => $val) {
-            if (in_array($key, ['mode', 'table', 'page', 'usage', 'region', 'idx', 'selidx', 'dir', 'field', 'keyword', 'old_idx'])) {
+            if (
+                in_array($key, ['mode', 'table', 'page', 'usage', 'region', 'idx', 'selidx', 'dir', 'field', 'keyword', 'old_idx']) ||
+                is_array($val)
+            ) {
                 continue;
             }
             $fields[] = "{$key}='" . addslashes(trim($val)) . "'";
@@ -208,6 +236,33 @@ switch ($mode) {
                     }
                 }
                 // else: 파일 선택 안 됐으면 기존 old_idx만 유지(삭제 안 함)
+            }
+        }
+
+        if ($table == 'competition') {
+            $db->query("DELETE FROM df_site_competition_part WHERE competition_idx=:idx", ['idx'=>$idx]);
+            $db->query("DELETE FROM df_site_competition_field WHERE competition_idx=:idx", ['idx'=>$idx]);
+            $db->query("DELETE FROM df_site_competition_event WHERE competition_idx=:idx", ['idx'=>$idx]);
+            $partArr  = isset($_POST['parts']) && is_array($_POST['parts']) ? $_POST['parts'] : [];
+            $fieldArr = isset($_POST['fields']) && is_array($_POST['fields']) ? $_POST['fields'] : [];
+            $eventArr = isset($_POST['events']) && is_array($_POST['events']) ? $_POST['events'] : [];
+            foreach ($partArr as $v) {
+                $v = trim($v);
+                if ($v !== '') {
+                    $db->query("INSERT INTO df_site_competition_part SET competition_idx=:c, f_part=:v", ['c'=>$idx,'v'=>$v]);
+                }
+            }
+            foreach ($fieldArr as $v) {
+                $v = trim($v);
+                if ($v !== '') {
+                    $db->query("INSERT INTO df_site_competition_field SET competition_idx=:c, f_field=:v", ['c'=>$idx,'v'=>$v]);
+                }
+            }
+            foreach ($eventArr as $v) {
+                $v = trim($v);
+                if ($v !== '') {
+                    $db->query("INSERT INTO df_site_competition_event SET competition_idx=:c, f_event=:v", ['c'=>$idx,'v'=>$v]);
+                }
             }
         }
 

--- a/competition/competition_sub03_apply.html
+++ b/competition/competition_sub03_apply.html
@@ -150,7 +150,7 @@
                                                                     </span>
                                                                 </td>
                                                                 <td align="left" class="info_td">
-                                                                    <select name="f_part" class="select"
+                                                                    <select name="f_part" id="f_part" class="select"
                                                                         data-required="y" data-label="참가부문을">
                                                                         <option value="">참가부문을 선택해주세요.</option>
                                                                         <option value="test">test</option>
@@ -172,7 +172,7 @@
                                                                     </span>
                                                                 </td>
                                                                 <td align="left" class="info_td">
-                                                                    <select name="f_field" class="select"
+                                                                    <select name="f_field" id="f_field" class="select"
                                                                         data-required="y" data-label="종목분야를">
                                                                         <option value="">종목분야를 선택해주세요.</option>
                                                                         <option value="test">test</option>
@@ -193,7 +193,7 @@
                                                                     </span>
                                                                 </td>
                                                                 <td align="left" class="info_td">
-                                                                    <select name="f_event" class="select"
+                                                                    <select name="f_event" id="f_event" class="select"
                                                                         data-required="y" data-label="참가종목을">
                                                                         <option value="">참가종목을 선택해주세요.</option>
                                                                         <option value="test">test</option>
@@ -685,7 +685,30 @@
         }).open();
     }
 </script>
+<script>
+    function loadOptions(idx){
+        $('#f_part').html('<option value="">참가부문을 선택해주세요.</option>');
+        $('#f_field').html('<option value="">종목분야를 선택해주세요.</option>');
+        $('#f_event').html('<option value="">참가종목을 선택해주세요.</option>');
+        if(!idx) return;
+        $.getJSON('/controller/competition_options.php?idx='+idx, function(res){
+            var html='<option value="">참가부문을 선택해주세요.</option>';
+            $.each(res.part, function(_,v){ html+='<option value="'+v+'">'+v+'</option>'; });
+            $('#f_part').html(html);
+            html='<option value="">종목분야를 선택해주세요.</option>';
+            $.each(res.field, function(_,v){ html+='<option value="'+v+'">'+v+'</option>'; });
+            $('#f_field').html(html);
+            html='<option value="">참가종목을 선택해주세요.</option>';
+            $.each(res.event, function(_,v){ html+='<option value="'+v+'">'+v+'</option>'; });
+            $('#f_event').html(html);
+        });
+    }
+    $(function(){
+        loadOptions($('#f_competition_idx').val());
+        $('#f_competition_idx').on('change', function(){ loadOptions(this.value); });
+    });
+</script>
 
 <?php
-	include $_SERVER['DOCUMENT_ROOT'].'/include/footer.html'; 
+        include $_SERVER['DOCUMENT_ROOT'].'/include/footer.html';
 ?>

--- a/competition/competition_sub03_apply02.html
+++ b/competition/competition_sub03_apply02.html
@@ -165,7 +165,7 @@
                                                                     </span>
                                                                 </td>
                                                                 <td align="left" class="info_td">
-                                                                    <select name="f_part" class="select"
+                                                                    <select name="f_part" id="f_part" class="select"
                                                                         data-required="y" data-label="참가부문을">
                                                                         <option value="">참가부문을 선택해주세요.</option>
                                                                         <option value="test">test</option>
@@ -187,7 +187,7 @@
                                                                     </span>
                                                                 </td>
                                                                 <td align="left" class="info_td">
-                                                                    <select name="f_field" class="select"
+                                                                    <select name="f_field" id="f_field" class="select"
                                                                         data-required="y" data-label="종목분야를">
                                                                         <option value="">종목분야를 선택해주세요.</option>
                                                                         <option value="test">test</option>
@@ -208,7 +208,7 @@
                                                                     </span>
                                                                 </td>
                                                                 <td align="left" class="info_td">
-                                                                    <select name="f_event" class="select"
+                                                                    <select name="f_event" id="f_event" class="select"
                                                                         data-required="y" data-label="참가종목을">
                                                                         <option value="">참가종목을 선택해주세요.</option>
                                                                         <option value="test">test</option>
@@ -710,7 +710,30 @@
         }).open();
     }
 </script>
+<script>
+    function loadOptions(idx){
+        $('#f_part').html('<option value="">참가부문을 선택해주세요.</option>');
+        $('#f_field').html('<option value="">종목분야를 선택해주세요.</option>');
+        $('#f_event').html('<option value="">참가종목을 선택해주세요.</option>');
+        if(!idx) return;
+        $.getJSON('/controller/competition_options.php?idx='+idx, function(res){
+            var html='<option value="">참가부문을 선택해주세요.</option>';
+            $.each(res.part, function(_,v){ html+='<option value="'+v+'">'+v+'</option>'; });
+            $('#f_part').html(html);
+            html='<option value="">종목분야를 선택해주세요.</option>';
+            $.each(res.field, function(_,v){ html+='<option value="'+v+'">'+v+'</option>'; });
+            $('#f_field').html(html);
+            html='<option value="">참가종목을 선택해주세요.</option>';
+            $.each(res.event, function(_,v){ html+='<option value="'+v+'">'+v+'</option>'; });
+            $('#f_event').html(html);
+        });
+    }
+    $(function(){
+        loadOptions($('#f_competition_idx').val());
+        $('#f_competition_idx').on('change', function(){ loadOptions(this.value); });
+    });
+</script>
 
 <?php
-	include $_SERVER['DOCUMENT_ROOT'].'/include/footer.html'; 
+        include $_SERVER['DOCUMENT_ROOT'].'/include/footer.html';
 ?>

--- a/controller/competition_options.php
+++ b/controller/competition_options.php
@@ -1,0 +1,18 @@
+<?php
+include $_SERVER['DOCUMENT_ROOT'].'/inc/global.inc';
+
+$idx = isset($_GET['idx']) ? (int)$_GET['idx'] : 0;
+header('Content-Type: application/json; charset=utf-8');
+if ($idx <= 0) {
+    echo json_encode(['part'=>[], 'field'=>[], 'event'=>[]]);
+    exit;
+}
+$parts  = $db->query("SELECT f_part FROM df_site_competition_part WHERE competition_idx=:idx ORDER BY idx ASC", ['idx'=>$idx]);
+$fields = $db->query("SELECT f_field FROM df_site_competition_field WHERE competition_idx=:idx ORDER BY idx ASC", ['idx'=>$idx]);
+$events = $db->query("SELECT f_event FROM df_site_competition_event WHERE competition_idx=:idx ORDER BY idx ASC", ['idx'=>$idx]);
+$ret = [
+    'part'  => array_map(function($row){ return $row['f_part']; }, $parts),
+    'field' => array_map(function($row){ return $row['f_field']; }, $fields),
+    'event' => array_map(function($row){ return $row['f_event']; }, $events),
+];
+echo json_encode($ret);

--- a/sql/create_df_site_competition_options.sql
+++ b/sql/create_df_site_competition_options.sql
@@ -1,0 +1,23 @@
+CREATE TABLE `df_site_competition_part` (
+  `idx` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'PK',
+  `competition_idx` int NOT NULL COMMENT '대회IDX',
+  `f_part` varchar(50) NOT NULL COMMENT '참가부문',
+  PRIMARY KEY (`idx`),
+  KEY `comp_idx` (`competition_idx`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='대회 참가부문 옵션';
+
+CREATE TABLE `df_site_competition_field` (
+  `idx` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'PK',
+  `competition_idx` int NOT NULL COMMENT '대회IDX',
+  `f_field` varchar(50) NOT NULL COMMENT '종목분야',
+  PRIMARY KEY (`idx`),
+  KEY `comp_idx` (`competition_idx`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='대회 종목분야 옵션';
+
+CREATE TABLE `df_site_competition_event` (
+  `idx` int unsigned NOT NULL AUTO_INCREMENT COMMENT 'PK',
+  `competition_idx` int NOT NULL COMMENT '대회IDX',
+  `f_event` varchar(100) NOT NULL COMMENT '참가종목',
+  PRIMARY KEY (`idx`),
+  KEY `comp_idx` (`competition_idx`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='대회 참가종목 옵션';


### PR DESCRIPTION
## Summary
- 대회에 참가부문/종목분야/참가종목 옵션을 등록할 수 있도록 기능 추가
- 옵션 조회용 `competition_options.php` 컨트롤러 작성
- 관리자 대회 등록/수정 화면에서 옵션 항목을 추가·삭제 가능하게 개선
- 신청 페이지에서 선택한 대회에 맞춰 옵션을 불러오도록 스크립트 구현
- 관련 SQL 스크립트 추가 및 exec 처리 로직 수정

## Testing
- `php -l controller/competition_options.php` *(실패: php 명령어 없음)*

------
https://chatgpt.com/codex/tasks/task_e_686b6667d9408322a2fc261472f098be