### PR TITLE
Support video slides

### DIFF
--- a/Madmin/main_slide/main_slide_input.php
+++ b/Madmin/main_slide/main_slide_input.php
@@ -13,7 +13,10 @@ $row = [
     'bottom_contents_pc' => '',
     'bottom_contents_m' => '',
     'thumbnail_pc' => '',
-    'thumbnail_m' => ''
+    'thumbnail_m' => '',
+    'media_type' => 'image',
+    'video_pc' => '',
+    'video_m' => ''
 ];
 if ($idx) {
     $row = $db->row("SELECT * FROM {$this_table} WHERE idx=:idx", ['idx' => $idx]);
@@ -75,6 +78,31 @@ if ($idx) {
                         <th>하단 문구(Mobile)</th>
                         <td class="comALeft"><textarea name="bottom_contents_m" class="form-control"
                                 style="width:80%;height:60px;"><?= htmlspecialchars($row['bottom_contents_m'], ENT_QUOTES) ?></textarea>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>타입</th>
+                        <td class="comALeft">
+                            <label><input type="radio" name="media_type" value="image" <?= $row['media_type']==='video' ? '' : 'checked' ?>> 이미지</label>
+                            <label style="margin-left:10px;"><input type="radio" name="media_type" value="video" <?= $row['media_type']==='video' ? 'checked' : '' ?>> 영상</label>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>PC 영상</th>
+                        <td class="comALeft">
+                            <input type="file" name="video_pc" class="form-control" style="width:60%;">
+                            <?php if ($mode == 'update' && $row['video_pc']): ?>
+                                <a href="/userfiles/main_slide/<?= $row['video_pc'] ?>" target="_blank"><?= $row['video_pc'] ?></a>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>Mobile 영상</th>
+                        <td class="comALeft">
+                            <input type="file" name="video_m" class="form-control" style="width:60%;">
+                            <?php if ($mode == 'update' && $row['video_m']): ?>
+                                <a href="/userfiles/main_slide/<?= $row['video_m'] ?>" target="_blank"><?= $row['video_m'] ?></a>
+                            <?php endif; ?>
                         </td>
                     </tr>
                     <tr>

--- a/Madmin/main_slide/main_slide_list.php
+++ b/Madmin/main_slide/main_slide_list.php
@@ -36,6 +36,7 @@ $list = $db->query("SELECT * FROM {$this_table} ORDER BY prior DESC");
                     <col width="200" />
                     <col width="200" />
                     <col width="80" />
+                    <col width="80" />
                     <col width="120" />
                 </colgroup>
                 <thead>
@@ -44,6 +45,7 @@ $list = $db->query("SELECT * FROM {$this_table} ORDER BY prior DESC");
                         <th>번호</th>
                         <th>PC 썸네일</th>
                         <th>모바일 썸네일</th>
+                        <th>타입</th>
                         <th>순서</th>
                         <th>작성일</th>
                     </tr>
@@ -68,6 +70,7 @@ $list = $db->query("SELECT * FROM {$this_table} ORDER BY prior DESC");
                                         <?php endif; ?>
                                     </a>
                                 </td>
+                                <td><?= $row['media_type'] ?></td>
                                 <td>
                                     <ul style="width:40px;margin:0 auto;padding:0;list-style:none;">
                                         <li style="float:left;width:20px;height:12px;text-align:center;">

--- a/Madmin/main_slide/main_slide_save.php
+++ b/Madmin/main_slide/main_slide_save.php
@@ -17,9 +17,12 @@ switch ($mode) {
             'bot_pc' => $_POST['bottom_contents_pc'] ?? '',
             'bot_m' => $_POST['bottom_contents_m'] ?? '',
             'prior' => $prior,
+            'media_type' => $_POST['media_type'] ?? 'image',
         ];
         $thumb_pc = '';
         $thumb_m = '';
+        $video_pc = '';
+        $video_m = '';
         if (!empty($_FILES['thumbnail_pc']['name'])) {
             $dir = $_SERVER['DOCUMENT_ROOT'] . '/userfiles/main_slide';
             if (!is_dir($dir))
@@ -36,10 +39,28 @@ switch ($mode) {
             $thumb_m = uniqid('m_') . '.' . $ext;
             move_uploaded_file($_FILES['thumbnail_m']['tmp_name'], "$dir/$thumb_m");
         }
+        if (!empty($_FILES['video_pc']['name'])) {
+            $dir = $_SERVER['DOCUMENT_ROOT'] . '/userfiles/main_slide';
+            if (!is_dir($dir))
+                mkdir($dir, 0755, true);
+            $ext = strtolower(pathinfo($_FILES['video_pc']['name'], PATHINFO_EXTENSION));
+            $video_pc = uniqid('vpc_') . '.' . $ext;
+            move_uploaded_file($_FILES['video_pc']['tmp_name'], "$dir/$video_pc");
+        }
+        if (!empty($_FILES['video_m']['name'])) {
+            $dir = $_SERVER['DOCUMENT_ROOT'] . '/userfiles/main_slide';
+            if (!is_dir($dir))
+                mkdir($dir, 0755, true);
+            $ext = strtolower(pathinfo($_FILES['video_m']['name'], PATHINFO_EXTENSION));
+            $video_m = uniqid('vm_') . '.' . $ext;
+            move_uploaded_file($_FILES['video_m']['tmp_name'], "$dir/$video_m");
+        }
         $params['thumb_pc'] = $thumb_pc;
         $params['thumb_m'] = $thumb_m;
+        $params['video_pc'] = $video_pc;
+        $params['video_m'] = $video_m;
         $db->query(
-            "INSERT INTO {$table} (top_contents_pc,top_contents_m,middle_contents_pc,middle_contents_m,bottom_contents_pc,bottom_contents_m,thumbnail_pc,thumbnail_m,prior,wdate) VALUES (:top_pc,:top_m,:mid_pc,:mid_m,:bot_pc,:bot_m,:thumb_pc,:thumb_m,:prior,NOW())",
+            "INSERT INTO {$table} (top_contents_pc,top_contents_m,middle_contents_pc,middle_contents_m,bottom_contents_pc,bottom_contents_m,thumbnail_pc,thumbnail_m,media_type,video_pc,video_m,prior,wdate) VALUES (:top_pc,:top_m,:mid_pc,:mid_m,:bot_pc,:bot_m,:thumb_pc,:thumb_m,:media_type,:video_pc,:video_m,:prior,NOW())",
             $params
         );
         complete('등록되었습니다.', '/Madmin/main_slide/main_slide_list.php');
@@ -55,7 +76,8 @@ switch ($mode) {
             'middle_contents_pc=:mid_pc',
             'middle_contents_m=:mid_m',
             'bottom_contents_pc=:bot_pc',
-            'bottom_contents_m=:bot_m'
+            'bottom_contents_m=:bot_m',
+            'media_type=:media_type'
         ];
         $params = [
             'top_pc' => $_POST['top_contents_pc'] ?? '',
@@ -64,6 +86,7 @@ switch ($mode) {
             'mid_m' => $_POST['middle_contents_m'] ?? '',
             'bot_pc' => $_POST['bottom_contents_pc'] ?? '',
             'bot_m' => $_POST['bottom_contents_m'] ?? '',
+            'media_type' => $_POST['media_type'] ?? 'image',
             'idx' => $idx
         ];
         if (!empty($_FILES['thumbnail_pc']['name'])) {
@@ -85,6 +108,26 @@ switch ($mode) {
             move_uploaded_file($_FILES['thumbnail_m']['tmp_name'], "$dir/$newm");
             $sets[] = 'thumbnail_m=:thumb_m';
             $params['thumb_m'] = $newm;
+        }
+        if (!empty($_FILES['video_pc']['name'])) {
+            $dir = $_SERVER['DOCUMENT_ROOT'] . '/userfiles/main_slide';
+            if (!is_dir($dir))
+                mkdir($dir, 0755, true);
+            $ext = strtolower(pathinfo($_FILES['video_pc']['name'], PATHINFO_EXTENSION));
+            $newvp = uniqid('vpc_') . '.' . $ext;
+            move_uploaded_file($_FILES['video_pc']['tmp_name'], "$dir/$newvp");
+            $sets[] = 'video_pc=:video_pc';
+            $params['video_pc'] = $newvp;
+        }
+        if (!empty($_FILES['video_m']['name'])) {
+            $dir = $_SERVER['DOCUMENT_ROOT'] . '/userfiles/main_slide';
+            if (!is_dir($dir))
+                mkdir($dir, 0755, true);
+            $ext = strtolower(pathinfo($_FILES['video_m']['name'], PATHINFO_EXTENSION));
+            $newvm = uniqid('vm_') . '.' . $ext;
+            move_uploaded_file($_FILES['video_m']['tmp_name'], "$dir/$newvm");
+            $sets[] = 'video_m=:video_m';
+            $params['video_m'] = $newvm;
         }
         $sql = "UPDATE {$table} SET " . implode(',', $sets) . " WHERE idx=:idx";
         $db->query($sql, $params);

--- a/index_tmp.html
+++ b/index_tmp.html
@@ -53,85 +53,23 @@
                                     </div>
                                 </div>
 
-                                <div class="bg w_con" style="background-image:url('/userfiles/main_slide/<?=$main_slide_row->thumbnail_pc?>');"></div>
-                                <div class="bg m_con" style="background-image:url('/userfiles/main_slide/<?=$main_slide_row->thumbnail_m?>');"></div>
-								
-								<!--
-								<div class="video">
-									<video loop muted autoplay playsinline class="w_video">
-										<source src="/img/main/test_bg.mp4" type="video/mp4" />
-									</video>
+                                <?php if($main_slide_row->media_type === 'video'): ?>
+                                <div class="video">
+                                        <video loop muted autoplay playsinline class="w_video">
+                                                <source src="/userfiles/main_slide/<?=$main_slide_row->video_pc?>" type="video/mp4" />
+                                        </video>
 
-									<video loop muted autoplay playsinline class="m_video">
-										<source src="/img/main/m_test_bg.mp4" type="video/mp4" />
-									</video>
-								</div>
-								-->
-                            </div>
-                        <?php } ?>
-
-						<?php 
-                        $main_slide_list = $db->query("SELECT * FROM df_site_main_slide ORDER BY prior desc", null, PDO::FETCH_OBJ);
-                        foreach ($main_slide_list as $main_slide_row) {
-                        ?>
-                            <div class="swiper-slide main_slide_div" data-swiper-autoplay="4000">
-                                <div class="contents_con">
-                                    <div class="text_con">
-                                        <div class="text01_con w_con">
-                                            <div class="bar"></div>
-                                            <span>
-                                                <?=nl2br($main_slide_row->top_contents_pc)?>
-                                            </span>
-                                        </div>
-                                        <div class="text01_con m_con">
-                                            <div class="bar"></div>
-                                            <span>
-                                                <?=nl2br($main_slide_row->top_contents_m)?>
-                                            </span>
-                                        </div>
-
-                                        <div class="text02_con w_con">
-                                            <span>
-                                                <?=nl2br($main_slide_row->middle_contents_pc)?>
-                                            </span>
-                                        </div>
-                                        <div class="text02_con m_con">
-                                            <span>
-                                                <?=nl2br($main_slide_row->middle_contents_m)?>
-                                            </span>
-                                        </div>
-
-                                        <div class="text03_con w_con">
-                                            <span>
-                                                <?=nl2br($main_slide_row->bottom_contents_pc)?>
-                                            </span>
-                                        </div>
-                                        <div class="text03_con m_con">
-                                            <span>
-                                                <?=nl2br($main_slide_row->bottom_contents_m)?>
-                                            </span>
-                                        </div>
-                                    </div>
+                                        <video loop muted autoplay playsinline class="m_video">
+                                                <source src="/userfiles/main_slide/<?=$main_slide_row->video_m?>" type="video/mp4" />
+                                        </video>
                                 </div>
-
-								<!--
+                                <?php else: ?>
                                 <div class="bg w_con" style="background-image:url('/userfiles/main_slide/<?=$main_slide_row->thumbnail_pc?>');"></div>
                                 <div class="bg m_con" style="background-image:url('/userfiles/main_slide/<?=$main_slide_row->thumbnail_m?>');"></div>
-								-->
-								
-							
-								<div class="video">
-									<video loop muted autoplay playsinline class="w_video">
-										<source src="/img/main/test_bg.mp4" type="video/mp4" />
-									</video>
-
-									<video loop muted autoplay playsinline class="m_video">
-										<source src="/img/main/m_test_bg.mp4" type="video/mp4" />
-									</video>
-								</div>
-								
+                                <?php endif; ?>
                             </div>
                         <?php } ?>
+
 					</div>
 
 					<div class="control_con">

--- a/sql/create_df_site_main_slide.sql
+++ b/sql/create_df_site_main_slide.sql
@@ -9,5 +9,8 @@ CREATE TABLE `df_site_main_slide` (
   `bottom_contents_m` MEDIUMTEXT,
   `thumbnail_pc` VARCHAR(500) COMMENT 'pc: 1920 * 998, m: 1080 * 1920',
   `thumbnail_m` VARCHAR(500) COMMENT 'pc: 1920 * 998, m: 1080 * 1920',
+  `media_type` VARCHAR(20) DEFAULT 'image' COMMENT 'image or video',
+  `video_pc` VARCHAR(500) DEFAULT NULL,
+  `video_m` VARCHAR(500) DEFAULT NULL,
   `prior` BIGINT
 ) ENGINE=InnoDB;


### PR DESCRIPTION
## Summary
- allow video type for slides
- admin UI now supports media type selection with video upload
- show slide type on admin list
- update main slide save logic to handle videos
- add video fields and type in db schema
- display video or image on frontend based on slide type

## Testing
- `php` command not available, unable to run syntax check

------
https://chatgpt.com/codex/tasks/task_e_686cb84795048322ae9c92807c01ee50