### PR TITLE
Add status update feature for registrations

### DIFF
--- a/Madmin/registration/reg_competition_status_update.php
+++ b/Madmin/registration/reg_competition_status_update.php
@@ -16,7 +16,8 @@ if (!in_array($status, ['ing', 'done', 'cancle', 'hold'], true)) {
 }
 
 $db->query(
-    'UPDATE df_site_application_registration SET f_applicant_status=:st WHERE idx=:idx',
+    'UPDATE df_site_competition_registration SET f_applicant_status=:st WHERE idx=:idx',
     ['st' => $status, 'idx' => $idx]
 );
-complete('신청결과가 변경되었습니다.', "reg_application_view.php?idx={$idx}&page={$page}");
+
+complete('신청결과가 변경되었습니다.', "reg_competition_view.php?idx={$idx}&page={$page}");

--- a/Madmin/registration/reg_competition_view.php
+++ b/Madmin/registration/reg_competition_view.php
@@ -152,6 +152,22 @@ function printType($val)
                     <td style="width:200px;">등록일</td>
                     <td><?= printValue($row['reg_date']) ?></td>
                 </tr>
+                <tr>
+                    <td style="width:200px;">신청결과</td>
+                    <td>
+                        <form method="post" action="reg_competition_status_update.php" style="display:inline-block;">
+                            <input type="hidden" name="idx" value="<?= $idx ?>">
+                            <input type="hidden" name="page" value="<?= $page ?>">
+                            <select name="f_applicant_status" class="form-control" style="width:auto;display:inline-block;">
+                                <option value="ing" <?= $row['f_applicant_status'] == 'ing' ? 'selected' : '' ?>>접수중</option>
+                                <option value="done" <?= $row['f_applicant_status'] == 'done' ? 'selected' : '' ?>>완료</option>
+                                <option value="cancle" <?= $row['f_applicant_status'] == 'cancle' ? 'selected' : '' ?>>취소</option>
+                                <option value="hold" <?= $row['f_applicant_status'] == 'hold' ? 'selected' : '' ?>>보류</option>
+                            </select>
+                            <button type="submit" class="btn btn-info btn-sm" style="margin-left:5px;">변경</button>
+                        </form>
+                    </td>
+                </tr>
             </table>
         </div>
     </div>
@@ -170,5 +186,4 @@ function printType($val)
     </div>
 </div>
 </body>
-
 </html>

--- a/Madmin/registration/reg_edu_status_update.php
+++ b/Madmin/registration/reg_edu_status_update.php
@@ -16,7 +16,8 @@ if (!in_array($status, ['ing', 'done', 'cancle', 'hold'], true)) {
 }
 
 $db->query(
-    'UPDATE df_site_application_registration SET f_applicant_status=:st WHERE idx=:idx',
+    'UPDATE df_site_edu_registration SET f_applicant_status=:st WHERE idx=:idx',
     ['st' => $status, 'idx' => $idx]
 );
-complete('신청결과가 변경되었습니다.', "reg_application_view.php?idx={$idx}&page={$page}");
+
+complete('신청결과가 변경되었습니다.', "reg_edu_view.php?idx={$idx}&page={$page}");

--- a/Madmin/registration/reg_edu_view.php
+++ b/Madmin/registration/reg_edu_view.php
@@ -146,6 +146,22 @@ function printType($val)
                     <td style="width:200px;">등록일</td>
                     <td><?= printValue($row['reg_date']) ?></td>
                 </tr>
+                <tr>
+                    <td style="width:200px;">신청결과</td>
+                    <td>
+                        <form method="post" action="reg_edu_status_update.php" style="display:inline-block;">
+                            <input type="hidden" name="idx" value="<?= $idx ?>">
+                            <input type="hidden" name="page" value="<?= $page ?>">
+                            <select name="f_applicant_status" class="form-control" style="width:auto;display:inline-block;">
+                                <option value="ing" <?= $row['f_applicant_status'] == 'ing' ? 'selected' : '' ?>>접수중</option>
+                                <option value="done" <?= $row['f_applicant_status'] == 'done' ? 'selected' : '' ?>>완료</option>
+                                <option value="cancle" <?= $row['f_applicant_status'] == 'cancle' ? 'selected' : '' ?>>취소</option>
+                                <option value="hold" <?= $row['f_applicant_status'] == 'hold' ? 'selected' : '' ?>>보류</option>
+                            </select>
+                            <button type="submit" class="btn btn-info btn-sm" style="margin-left:5px;">변경</button>
+                        </form>
+                    </td>
+                </tr>
             </table>
         </div>
     </div>
@@ -164,5 +180,4 @@ function printType($val)
     </div>
 </div>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- update `reg_application_status_update.php` to store status strings
- add status update forms to edu and competition views
- create `reg_edu_status_update.php` and `reg_competition_status_update.php`

## Testing
- `php -l Madmin/registration/reg_application_status_update.php`
- `php -l Madmin/registration/reg_edu_status_update.php`
- `php -l Madmin/registration/reg_competition_status_update.php`
- `php -l Madmin/registration/reg_edu_view.php`
- `php -l Madmin/registration/reg_competition_view.php`


------
https://chatgpt.com/codex/tasks/task_e_686e26a9a8c483229ec3e25bf7c64f81