### PR TITLE
Implement application cancel via POST

### DIFF
--- a/mypage/application_cancel.php
+++ b/mypage/application_cancel.php
@@ -1,0 +1,31 @@
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/global.inc';
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/util_lib.inc';
+
+$idx = isset($_POST['idx']) ? (int)$_POST['idx'] : 0;
+if ($idx <= 0) {
+    error('잘못된 접근입니다.');
+}
+
+$table = null;
+$row = $db->row('SELECT f_applicant_status FROM df_site_application_registration WHERE idx=:idx', ['idx' => $idx]);
+if ($row) {
+    $table = 'df_site_application_registration';
+} else {
+    $row = $db->row('SELECT f_applicant_status FROM df_site_edu_registration WHERE idx=:idx', ['idx' => $idx]);
+    if ($row) {
+        $table = 'df_site_edu_registration';
+    }
+}
+
+if (!$row) {
+    error('신청 정보를 찾을 수 없습니다.');
+}
+
+if ($row['f_applicant_status'] === 'ing') {
+    $db->query("UPDATE {$table} SET f_applicant_status='cancle' WHERE idx=:idx", ['idx' => $idx]);
+    complete('신청취소가 완료되었습니다.', '/mypage/history.html');
+} else {
+    echo '<script>alert("관리자가 ing 제외한 상태로 이미 수정한 경우에는 취소가 불가능 합니다.");history.back();</script>';
+}
+

--- a/mypage/history_view_education.html
+++ b/mypage/history_view_education.html
@@ -995,9 +995,10 @@ if (!$row) {
                                 </div>
 
                                 <div class="btn_con">
-									<a href="#" class="a_btn a_btn01">
-                                        신청취소
-                                    </a>
+                                    <form action="/mypage/application_cancel.php" method="post" style="display:inline;">
+                                        <input type="hidden" name="idx" value="<?= $idx ?>">
+                                        <button type="submit" class="a_btn a_btn01">신청취소</button>
+                                    </form>
 
                                     <a href="/mypage/history.html" class="a_btn a_btn02">
                                         목록으로

--- a/mypage/history_view_license.html
+++ b/mypage/history_view_license.html
@@ -1433,9 +1433,10 @@ $p_value = implode(', ', $labels);
                                 </div>
 
                                 <div class="btn_con">
-									<a href="#" class="a_btn a_btn01">
-                                        신청취소
-                                    </a>
+                                    <form action="/mypage/application_cancel.php" method="post" style="display:inline;">
+                                        <input type="hidden" name="idx" value="<?= $idx ?>">
+                                        <button type="submit" class="a_btn a_btn01">신청취소</button>
+                                    </form>
 
                                     <a href="/mypage/history.html" class="a_btn a_btn02">
                                         목록으로


### PR DESCRIPTION
## Summary
- allow cancelling applications via POST form
- add new script `application_cancel.php`
- link cancel buttons in history view pages to new POST handler

## Testing
- `php -l mypage/application_cancel.php`
- `php -l mypage/history_view_license.html`
- `php -l mypage/history_view_education.html`


------
https://chatgpt.com/codex/tasks/task_e_686e2920abd8832297f41076e41d58d1