### PR TITLE
mypage 상태 출력 개선

### DIFF
--- a/mypage/history.html
+++ b/mypage/history.html
@@ -36,15 +36,17 @@
 
         function printStatus($val)
         {
-            switch ((int) $val) {
-                case 1:
-                    return '접수완료';
-                case 2:
-                    return '발급완료';
-                case 3:
-                    return '발급보류';
+            switch ($val) {
+                case 'ing':
+                    return '접수중';
+                case 'done':
+                    return '완료';
+                case 'cancle':
+                    return '취소';
+                case 'hold':
+                    return '보류';
                 default:
-                    return '';
+                    return $val;
             }
         }
 ?>

--- a/mypage/history_view_license.html
+++ b/mypage/history_view_license.html
@@ -24,15 +24,17 @@ $schedule_str = $row['f_schedule_idx'] == 0 ? '상시접수'
 
 function printStatus($val)
 {
-    switch ((int) $val) {
-        case 1:
-            return '접수완료';
-        case 2:
-            return '발급완료';
-        case 3:
-            return '발급보류';
+    switch ($val) {
+        case 'ing':
+            return '접수중';
+        case 'done':
+            return '완료';
+        case 'cancle':
+            return '취소';
+        case 'hold':
+            return '보류';
         default:
-            return '';
+            return $val;
     }
 }
 


### PR DESCRIPTION
## Summary
- 마이페이지 신청 이력 화면에서 결과 상태를 문자열 코드에 맞춰 표시
- 상세 보기 페이지의 결과 상태 처리도 동일하게 수정

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e2f6a5dc8832287fef243787cde7d