### PR TITLE
Add applicant status filters

### DIFF
--- a/Madmin/registration/reg_application_excel.php
+++ b/Madmin/registration/reg_application_excel.php
@@ -3,6 +3,7 @@ include "../../inc/global.inc";
 include "../../inc/util_lib.inc";
 
 $filename = iconv('UTF-8', 'EUC-KR', "자격시험신청_" . date('Ymd') . ".xls");
+$status = $_GET['status'] ?? '';
 
 header("Content-Type: application/vnd.ms-excel; charset=UTF-8");
 header("Content-Disposition: attachment; filename={$filename}");
@@ -23,11 +24,26 @@ $application_type_map = [
     'cert' => '자격증 발급',
 ];
 
+$status_map = [
+    'ing'   => '접수중',
+    'done'  => '완료',
+    'cancle' => '취소',
+    'hold'  => '보류',
+];
+
+$where = '';
+$params = [];
+if ($status !== '') {
+    $where = 'WHERE t1.f_applicant_status = :status';
+    $params['status'] = $status;
+}
+
 $list = $db->query("SELECT t1.*, t2.f_item_name, s.f_year, s.f_round, s.f_type
         FROM df_site_application_registration t1
         LEFT JOIN df_site_qualification_item t2 ON t1.f_item_idx = t2.idx
         LEFT JOIN df_site_application s ON t1.f_schedule_idx = s.idx
-        ORDER BY t1.idx DESC");
+        {$where}
+        ORDER BY t1.idx DESC", $params);
 
 echo "<table border='1'>";
 echo "<tr>";
@@ -39,6 +55,7 @@ echo "<th>이름</th>";
 echo "<th>신청구분</th>";
 echo "<th>연락처</th>";
 echo "<th>이메일</th>";
+echo "<th>상태</th>";
 echo "<th>등록일</th>";
 echo "</tr>";
 
@@ -61,10 +78,10 @@ foreach ($list as $row) {
     echo "<td>" . safeAdminOutput($application_type_map[$row['f_application_type']]) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_tel']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_email']) . "</td>";
+    echo "<td>" . safeAdminOutput($status_map[$row['f_applicant_status']] ?? $row['f_applicant_status']) . "</td>";
     echo "<td>" . safeAdminOutput($row['wdate']) . "</td>";
     echo "</tr>";
     $no--;
 }
 
-echo "</table>";
-?>
+echo "</table>";?>

--- a/Madmin/registration/reg_application_list.php
+++ b/Madmin/registration/reg_application_list.php
@@ -2,11 +2,20 @@
 include $_SERVER['DOCUMENT_ROOT'] . "/Madmin/inc/top.php";
 
 $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
+$status = $_GET['status'] ?? '';
+$param = "status={$status}";
 $page_set = 15;
 $block_set = 10;
 
-$sql = "SELECT COUNT(*) FROM df_site_application_registration";
-$total = $db->single($sql);
+$where = 'WHERE 1';
+$params = [];
+if ($status !== '') {
+    $where .= ' AND t1.f_applicant_status=:status';
+    $params['status'] = $status;
+}
+
+$sql = "SELECT COUNT(*) FROM df_site_application_registration t1 {$where}";
+$total = $db->single($sql, $params);
 
 $pageCnt = (int) (($total - 1) / $page_set) + 1;
 if ($page > $pageCnt) {
@@ -20,8 +29,9 @@ if ($total > 0) {
             FROM df_site_application_registration t1
             LEFT JOIN df_site_qualification_item t2 ON t1.f_item_idx = t2.idx
             LEFT JOIN df_site_application s ON t1.f_schedule_idx = s.idx
+            {$where}
             ORDER BY t1.idx DESC LIMIT {$offset}, {$page_set}";
-    $list = $db->query($sql);
+    $list = $db->query($sql, $params);
 }
 
 $category_map = [
@@ -37,6 +47,13 @@ $category_map = [
 $application_type_map = [
     'exam' => '시헙 접수',
     'cert' => '자격증 발급',
+];
+
+$status_map = [
+    'ing'   => '접수중',
+    'done'  => '완료',
+    'cancle' => '취소',
+    'hold'  => '보류',
 ];
 ?>
 <style>
@@ -64,6 +81,26 @@ $application_type_map = [
         </tr>
     </table>
 
+    <form action="<?= $_SERVER['PHP_SELF'] ?>" method="get">
+        <input type="hidden" name="page" value="<?= $page ?>">
+        <table class="comMTop20" cellpadding="0" cellspacing="0" style="width:1114px;">
+            <tr>
+                <td width="5"></td>
+                <td align="left">
+                    <select name="status" class="form-control" style="width:auto; display:inline-block;">
+                        <option value="" <?= $status === '' ? 'selected' : '' ?>>전체</option>
+                        <option value="ing" <?= $status === 'ing' ? 'selected' : '' ?>>접수중</option>
+                        <option value="done" <?= $status === 'done' ? 'selected' : '' ?>>완료</option>
+                        <option value="cancle" <?= $status === 'cancle' ? 'selected' : '' ?>>취소</option>
+                        <option value="hold" <?= $status === 'hold' ? 'selected' : '' ?>>보류</option>
+                    </select>
+                    <button class="btn btn-info btn-sm" type="submit">검색</button>
+                </td>
+                <td width="5"></td>
+            </tr>
+        </table>
+    </form>
+
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table" cellpadding="0" cellspacing="0">
@@ -74,6 +111,7 @@ $application_type_map = [
                 <col width="130" />
                 <col width="120" />
                 <col width="170" />
+                <col width="90" />
                 <col width="190" />
                 <col width="150" />
                 <thead>
@@ -86,6 +124,7 @@ $application_type_map = [
                         <td>신청구분</td>
                         <td>연락처</td>
                         <td>이메일</td>
+                        <td>상태</td>
                         <td>등록일</td>
                     </tr>
                 </thead>
@@ -111,12 +150,13 @@ $application_type_map = [
                                 <td><?= htmlspecialchars($application_type_map[$row['f_application_type']], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($row['f_tel'], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($row['f_email'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($status_map[$row['f_applicant_status']] ?? $row['f_applicant_status'], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($row['wdate'], ENT_QUOTES) ?></td>
                             </tr>
                         <?php endforeach; ?>
                     <?php else: ?>
                         <tr>
-                            <td colspan="8" align="center">등록된 데이터가 없습니다.</td>
+                            <td colspan="10" align="center">등록된 데이터가 없습니다.</td>
                         </tr>
                     <?php endif; ?>
                 </tbody>
@@ -126,12 +166,11 @@ $application_type_map = [
     <div class="box comMTop20 comMBottom20" style="width:1114px;">
         <div class="comPTop20 comPBottom20">
             <div class="comFCenter comACenter" style="width:100%; display:inline-block;">
-                <?php print_pagelist_admin($total, $page_set, $block_set, $page, ""); ?>
+                <?php print_pagelist_admin($total, $page_set, $block_set, $page, '&' . $param); ?>
             </div>
             <div class="clear"></div>
         </div>
     </div>
 </div>
 </body>
-
 </html>

--- a/Madmin/registration/reg_competition_excel.php
+++ b/Madmin/registration/reg_competition_excel.php
@@ -3,15 +3,31 @@ include "../../inc/global.inc";
 include "../../inc/util_lib.inc";
 
 $filename = iconv('UTF-8', 'EUC-KR', "대회신청_" . date('Ymd') . ".xls");
+$status = $_GET['status'] ?? '';
 
 header("Content-Type: application/vnd.ms-excel; charset=UTF-8");
 header("Content-Disposition: attachment; filename={$filename}");
 header("Content-Description: PHP Generated Data");
 
+$status_map = [
+    'ing'   => '접수중',
+    'done'  => '완료',
+    'cancle' => '취소',
+    'hold'  => '보류',
+];
+
+$where = '';
+$params = [];
+if ($status !== '') {
+    $where = 'WHERE t1.f_applicant_status = :status';
+    $params['status'] = $status;
+}
+
 $list = $db->query("SELECT t1.*, t2.f_title
         FROM df_site_competition_registration t1
         LEFT JOIN df_site_competition t2 ON t1.f_competition_idx = t2.idx
-        ORDER BY t1.idx DESC");
+        {$where}
+        ORDER BY t1.idx DESC", $params);
 
 echo "<table border='1'>";
 echo "<tr>";
@@ -23,6 +39,7 @@ echo "<th>참가종목</th>";
 echo "<th>이름</th>";
 echo "<th>연락처</th>";
 echo "<th>이메일</th>";
+echo "<th>상태</th>";
 echo "<th>등록일</th>";
 echo "</tr>";
 
@@ -37,10 +54,10 @@ foreach ($list as $row) {
     echo "<td>" . safeAdminOutput($row['f_user_name']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_tel']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_email']) . "</td>";
+    echo "<td>" . safeAdminOutput($status_map[$row['f_applicant_status']] ?? $row['f_applicant_status']) . "</td>";
     echo "<td>" . safeAdminOutput($row['reg_date']) . "</td>";
     echo "</tr>";
     $no--;
 }
 
-echo "</table>";
-?>
+echo "</table>";?>

--- a/Madmin/registration/reg_competition_list.php
+++ b/Madmin/registration/reg_competition_list.php
@@ -2,11 +2,27 @@
 include $_SERVER['DOCUMENT_ROOT'] . "/Madmin/inc/top.php";
 
 $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
+$status = $_GET['status'] ?? '';
+$param = "status={$status}";
 $page_set = 15;
 $block_set = 10;
 
-$sql = "SELECT COUNT(*) FROM df_site_competition_registration";
-$total = $db->single($sql);
+$where = 'WHERE 1';
+$params = [];
+if ($status !== '') {
+    $where .= ' AND t1.f_applicant_status=:status';
+    $params['status'] = $status;
+}
+
+$sql = "SELECT COUNT(*) FROM df_site_competition_registration t1 {$where}";
+$total = $db->single($sql, $params);
+
+$status_map = [
+    'ing'   => '접수중',
+    'done'  => '완료',
+    'cancle' => '취소',
+    'hold'  => '보류',
+];
 
 $pageCnt = (int) (($total - 1) / $page_set) + 1;
 if ($page > $pageCnt) {
@@ -18,8 +34,9 @@ if ($total > 0) {
     $offset = ($page - 1) * $page_set;
     $sql = "SELECT t1.*, t2.f_title FROM df_site_competition_registration t1
             LEFT JOIN df_site_competition t2 on t1.f_competition_idx = t2.idx
-            ORDER BY idx DESC LIMIT {$offset}, {$page_set}";
-    $list = $db->query($sql);
+            {$where}
+            ORDER BY t1.idx DESC LIMIT {$offset}, {$page_set}";
+    $list = $db->query($sql, $params);
 }
 ?>
 <style>
@@ -45,6 +62,26 @@ if ($total > 0) {
             <td width="5"></td>
         </tr>
     </table>
+
+    <form action="<?= $_SERVER['PHP_SELF'] ?>" method="get">
+        <input type="hidden" name="page" value="<?= $page ?>">
+        <table class="comMTop20" cellpadding="0" cellspacing="0" style="width:1114px;">
+            <tr>
+                <td width="5"></td>
+                <td align="left">
+                    <select name="status" class="form-control" style="width:auto; display:inline-block;">
+                        <option value="" <?= $status === '' ? 'selected' : '' ?>>전체</option>
+                        <option value="ing" <?= $status === 'ing' ? 'selected' : '' ?>>접수중</option>
+                        <option value="done" <?= $status === 'done' ? 'selected' : '' ?>>완료</option>
+                        <option value="cancle" <?= $status === 'cancle' ? 'selected' : '' ?>>취소</option>
+                        <option value="hold" <?= $status === 'hold' ? 'selected' : '' ?>>보류</option>
+                    </select>
+                    <button class="btn btn-info btn-sm" type="submit">검색</button>
+                </td>
+                <td width="5"></td>
+            </tr>
+        </table>
+    </form>
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table" cellpadding="0" cellspacing="0">
@@ -55,6 +92,7 @@ if ($total > 0) {
                 <col width="120" />
                 <col width="150" />
                 <col width="150" />
+                <col width="90" />
                 <col width="190" />
                 <col width="150" />
                 <thead>
@@ -67,6 +105,7 @@ if ($total > 0) {
                         <td>이름</td>
                         <td>연락처</td>
                         <td>이메일</td>
+                        <td>상태</td>
                         <td>등록일</td>
                     </tr>
                 </thead>
@@ -84,12 +123,13 @@ if ($total > 0) {
                                 </td>
                                 <td><?= htmlspecialchars($row['f_tel'], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($row['f_email'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($status_map[$row['f_applicant_status']] ?? $row['f_applicant_status'], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($row['reg_date'], ENT_QUOTES) ?></td>
                             </tr>
                         <?php endforeach; ?>
                     <?php else: ?>
                         <tr>
-                            <td colspan="9" align="center">등록된 데이터가 없습니다.</td>
+                            <td colspan="10" align="center">등록된 데이터가 없습니다.</td>
                         </tr>
                     <?php endif; ?>
                 </tbody>
@@ -99,12 +139,11 @@ if ($total > 0) {
     <div class="box comMTop20 comMBottom20" style="width:1114px;">
         <div class="comPTop20 comPBottom20">
             <div class="comFCenter comACenter" style="width:100%; display:inline-block;">
-                <?php print_pagelist_admin($total, $page_set, $block_set, $page, ""); ?>
+                <?php print_pagelist_admin($total, $page_set, $block_set, $page, '&' . $param); ?>
             </div>
             <div class="clear"></div>
         </div>
     </div>
 </div>
 </body>
-
 </html>

--- a/Madmin/registration/reg_edu_excel.php
+++ b/Madmin/registration/reg_edu_excel.php
@@ -3,12 +3,27 @@ include "../../inc/global.inc";
 include "../../inc/util_lib.inc";
 
 $filename = iconv('UTF-8', 'EUC-KR', "교육신청_" . date('Ymd') . ".xls");
+$status = $_GET['status'] ?? '';
 
 header("Content-Type: application/vnd.ms-excel; charset=UTF-8");
 header("Content-Disposition: attachment; filename={$filename}");
 header("Content-Description: PHP Generated Data");
 
-$list = $db->query("SELECT * FROM df_site_edu_registration ORDER BY idx DESC");
+$status_map = [
+    'ing'   => '접수중',
+    'done'  => '완료',
+    'cancle' => '취소',
+    'hold'  => '보류',
+];
+
+$where = '';
+$params = [];
+if ($status !== '') {
+    $where = 'WHERE f_applicant_status = :status';
+    $params['status'] = $status;
+}
+
+$list = $db->query("SELECT * FROM df_site_edu_registration {$where} ORDER BY idx DESC", $params);
 
 echo "<table border='1'>";
 echo "<tr>";
@@ -18,6 +33,7 @@ echo "<th>교육구분</th>";
 echo "<th>이름</th>";
 echo "<th>연락처</th>";
 echo "<th>이메일</th>";
+echo "<th>상태</th>";
 echo "<th>등록일</th>";
 echo "</tr>";
 
@@ -30,10 +46,10 @@ foreach ($list as $row) {
     echo "<td>" . safeAdminOutput($row['f_user_name']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_tel']) . "</td>";
     echo "<td>" . safeAdminOutput($row['f_email']) . "</td>";
+    echo "<td>" . safeAdminOutput($status_map[$row['f_applicant_status']] ?? $row['f_applicant_status']) . "</td>";
     echo "<td>" . safeAdminOutput($row['reg_date']) . "</td>";
     echo "</tr>";
     $no--;
 }
 
-echo "</table>";
-?>
+echo "</table>";?>

--- a/Madmin/registration/reg_edu_list.php
+++ b/Madmin/registration/reg_edu_list.php
@@ -2,11 +2,27 @@
 include $_SERVER['DOCUMENT_ROOT'] . "/Madmin/inc/top.php";
 
 $page = isset($_GET['page']) ? (int) $_GET['page'] : 1;
+$status = $_GET['status'] ?? '';
+$param = "status={$status}";
 $page_set = 15;
 $block_set = 10;
 
-$sql = "SELECT COUNT(*) FROM df_site_edu_registration";
-$total = $db->single($sql);
+$where = 'WHERE 1';
+$params = [];
+if ($status !== '') {
+    $where .= ' AND f_applicant_status=:status';
+    $params['status'] = $status;
+}
+
+$sql = "SELECT COUNT(*) FROM df_site_edu_registration {$where}";
+$total = $db->single($sql, $params);
+
+$status_map = [
+    'ing'   => '접수중',
+    'done'  => '완료',
+    'cancle' => '취소',
+    'hold'  => '보류',
+];
 
 $pageCnt = (int) (($total - 1) / $page_set) + 1;
 if ($page > $pageCnt) {
@@ -16,8 +32,8 @@ if ($page > $pageCnt) {
 $list = [];
 if ($total > 0) {
     $offset = ($page - 1) * $page_set;
-    $sql = "SELECT * FROM df_site_edu_registration ORDER BY idx DESC LIMIT {$offset}, {$page_set}";
-    $list = $db->query($sql);
+    $sql = "SELECT * FROM df_site_edu_registration {$where} ORDER BY idx DESC LIMIT {$offset}, {$page_set}";
+    $list = $db->query($sql, $params);
 }
 ?>
 <style>
@@ -42,6 +58,27 @@ if ($total > 0) {
             <td width="5"></td>
         </tr>
     </table>
+
+    <form action="<?= $_SERVER['PHP_SELF'] ?>" method="get">
+        <input type="hidden" name="page" value="<?= $page ?>">
+        <table class="comMTop20" cellpadding="0" cellspacing="0" style="width:1114px;">
+            <tr>
+                <td width="5"></td>
+                <td align="left">
+                    <select name="status" class="form-control" style="width:auto; display:inline-block;">
+                        <option value="" <?= $status === '' ? 'selected' : '' ?>>전체</option>
+                        <option value="ing" <?= $status === 'ing' ? 'selected' : '' ?>>접수중</option>
+                        <option value="done" <?= $status === 'done' ? 'selected' : '' ?>>완료</option>
+                        <option value="cancle" <?= $status === 'cancle' ? 'selected' : '' ?>>취소</option>
+                        <option value="hold" <?= $status === 'hold' ? 'selected' : '' ?>>보류</option>
+                    </select>
+                    <button class="btn btn-info btn-sm" type="submit">검색</button>
+                </td>
+                <td width="5"></td>
+            </tr>
+        </table>
+    </form>
+
     <div class="box comMTop20" style="width:1114px;">
         <div class="panel">
             <table class="table" cellpadding="0" cellspacing="0">
@@ -51,6 +88,7 @@ if ($total > 0) {
                 <col width="150" />
                 <col width="150" />
                 <col width="200" />
+                <col width="90" />
                 <col width="150" />
                 <thead>
                     <tr>
@@ -60,6 +98,7 @@ if ($total > 0) {
                         <td>이름</td>
                         <td>연락처</td>
                         <td>이메일</td>
+                        <td>상태</td>
                         <td>등록일</td>
                     </tr>
                 </thead>
@@ -75,12 +114,13 @@ if ($total > 0) {
                                 </td>
                                 <td><?= htmlspecialchars($row['f_tel'], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($row['f_email'], ENT_QUOTES) ?></td>
+                                <td><?= htmlspecialchars($status_map[$row['f_applicant_status']] ?? $row['f_applicant_status'], ENT_QUOTES) ?></td>
                                 <td><?= htmlspecialchars($row['reg_date'], ENT_QUOTES) ?></td>
                             </tr>
                         <?php endforeach; ?>
                     <?php else: ?>
                         <tr>
-                            <td colspan="7" align="center">등록된 데이터가 없습니다.</td>
+                            <td colspan="8" align="center">등록된 데이터가 없습니다.</td>
                         </tr>
                     <?php endif; ?>
                 </tbody>
@@ -90,12 +130,11 @@ if ($total > 0) {
     <div class="box comMTop20 comMBottom20" style="width:1114px;">
         <div class="comPTop20 comPBottom20">
             <div class="comFCenter comACenter" style="width:100%; display:inline-block;">
-                <?php print_pagelist_admin($total, $page_set, $block_set, $page, ""); ?>
+                <?php print_pagelist_admin($total, $page_set, $block_set, $page, '&' . $param); ?>
             </div>
             <div class="clear"></div>
         </div>
     </div>
 </div>
 </body>
-
 </html>


### PR DESCRIPTION
## Summary
- 리스트 페이지와 엑셀 다운로드에 신청 상태(f_applicant_status) 표시
- 상태별 검색 필터 추가

## Testing
- `php -l Madmin/registration/reg_application_list.php`
- `php -l Madmin/registration/reg_competition_list.php`
- `php -l Madmin/registration/reg_edu_list.php`
- `php -l Madmin/registration/reg_application_excel.php`
- `php -l Madmin/registration/reg_competition_excel.php`
- `php -l Madmin/registration/reg_edu_excel.php`


------
https://chatgpt.com/codex/tasks/task_e_686e2da994e4832297a5db47e9fafebb