### PR TITLE
Fix personal application file uploads

### DIFF
--- a/center/center_sub_apply.php
+++ b/center/center_sub_apply.php
@@ -575,7 +575,7 @@ unset($sc);
 																															<span>
 																																파일선택
 																															</span>
-																															<input type="file" name="upfile" class="input" onchange="file_upload(this.value)" />
+                                                                               <input type="file" name="upfile[]" class="input" onchange="file_upload(this.value)" />
 																														</label>
 																													</td>
 																												</tr>
@@ -891,7 +891,7 @@ unset($sc);
 	}
 
 	// 파일 input change 이벤트도 추가로 처리
-	$(document).on("change", "input[type='file'][name='upfile']", function(){
+        $(document).on("change", "input[type='file'][name^='upfile']", function(){
 		var fileName = this.value.split('\\').pop().split('/').pop();
 		$(this).closest('.apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li .file_div').find("input[name='upfile_name']").val(fileName);
 	});

--- a/controller/applicate_controller.php
+++ b/controller/applicate_controller.php
@@ -41,6 +41,29 @@ function upload_file(array $file): array
     return ['saved' => $new, 'original' => $orig];
 }
 
+function upload_files(array $files): array
+{
+    $saved = [];
+    if (!isset($files['name']) || !is_array($files['name'])) {
+        return $saved;
+    }
+    $cnt = count($files['name']);
+    for ($i = 0; $i < $cnt; $i++) {
+        if (empty($files['name'][$i])) {
+            continue;
+        }
+        $fileInfo = [
+            'name' => $files['name'][$i],
+            'tmp_name' => $files['tmp_name'][$i] ?? '',
+            'size' => $files['size'][$i] ?? 0,
+            'error' => $files['error'][$i] ?? UPLOAD_ERR_NO_FILE,
+        ];
+        $info = upload_file($fileInfo);
+        $saved[] = $info['saved'];
+    }
+    return $saved;
+}
+
 if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
     return_json(['result' => 'error', 'msg' => '잘못된 요청입니다.']);
 }
@@ -102,11 +125,18 @@ if (empty($filtered['agree_privacy'])) {
 $birth_date = str_replace('.', '-', $filtered['f_birth_date']);
 $payment_cat = implode(',', $filtered['f_payment_category']);
 
-$uploadName = null;
+$uploadNames = [];
 if (!empty($_FILES['f_issue_file']['name'])) {
     $info = upload_file($_FILES['f_issue_file']);
-    $uploadName = $info['saved'];
+    $uploadNames[] = $info['saved'];
 }
+if (!empty($_FILES['upfile']['name'])) {
+    $uploaded = upload_files($_FILES['upfile']);
+    if ($uploaded) {
+        $uploadNames = array_merge($uploadNames, $uploaded);
+    }
+}
+$uploadName = $uploadNames ? implode(',', $uploadNames) : null;
 
 $f_user_id = isset($_SESSION['kbga_user_id']) && $_SESSION['kbga_user_id'] != '' ? $_SESSION['kbga_user_id'] : '';
 

--- a/mypage/history_view_license.html
+++ b/mypage/history_view_license.html
@@ -604,22 +604,20 @@ $p_value = implode(', ', $labels);
                                                                                                                         value="<?= htmlspecialchars($row['f_issue_file'], ENT_QUOTES) ?>"
                                                                                                                         class="input"
                                                                                                                         readonly="readonly" /> -->
-                                                                                                                        <?php if (!empty($row['f_issue_file'])): ?>
-                                                                                                                            <?php
-                                                                                                                            $fileName = $row['f_issue_file'];
-                                                                                                                            $fileUrl = '/userfiles/registration/' . rawurlencode($fileName);
-                                                                                                                            ?>
-                                                                                                                            <a href="<?= htmlspecialchars($fileUrl, ENT_QUOTES) ?>"
-                                                                                                                                download="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>"
-                                                                                                                                class="download-link">
-                                                                                                                                <?= htmlspecialchars($fileName, ENT_QUOTES) ?>
-                                                                                                                            </a>
-                                                                                                                        <?php else: ?>
-                                                                                                                            <span
-                                                                                                                                class="no-file">
-                                                                                                                                파일이
-                                                                                                                                없습니다.</span>
-                                                                                                                        <?php endif; ?>
+                                                <?php if (!empty($row['f_issue_file'])): ?>
+                                                    <?php $files_arr = explode(',', $row['f_issue_file']);
+                                                    foreach ($files_arr as $fileName):
+                                                        $fileUrl = '/userfiles/registration/' . rawurlencode($fileName);
+                                                    ?>
+                                                        <a href="<?= htmlspecialchars($fileUrl, ENT_QUOTES) ?>"
+                                                            download="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>"
+                                                            class="download-link">
+                                                            <?= htmlspecialchars($fileName, ENT_QUOTES) ?>
+                                                        </a><br>
+                                                    <?php endforeach; ?>
+                                                <?php else: ?>
+                                                    <span class="no-file">파일이 없습니다.</span>
+                                                <?php endif; ?>
                                                                                                                     </td>
                                                                                                                 </tr>
                                                                                                             </tbody>
@@ -1217,22 +1215,20 @@ $p_value = implode(', ', $labels);
                                                                                                                             value="<?= htmlspecialchars($row['f_issue_file'], ENT_QUOTES) ?>"
                                                                                                                             class="input"
                                                                                                                             readonly="readonly" /> -->
-                                                                                                                        <?php if (!empty($row['f_issue_file'])): ?>
-                                                                                                                            <?php
-                                                                                                                            $fileName = $row['f_issue_file'];
-                                                                                                                            $fileUrl = '/userfiles/registration/' . rawurlencode($fileName);
-                                                                                                                            ?>
-                                                                                                                            <a href="<?= htmlspecialchars($fileUrl, ENT_QUOTES) ?>"
-                                                                                                                                download="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>"
-                                                                                                                                class="download-link">
-                                                                                                                                <?= htmlspecialchars($fileName, ENT_QUOTES) ?>
-                                                                                                                            </a>
-                                                                                                                        <?php else: ?>
-                                                                                                                            <span
-                                                                                                                                class="no-file">
-                                                                                                                                파일이
-                                                                                                                                없습니다.</span>
-                                                                                                                        <?php endif; ?>
+                                                <?php if (!empty($row['f_issue_file'])): ?>
+                                                    <?php $files_arr = explode(',', $row['f_issue_file']);
+                                                    foreach ($files_arr as $fileName):
+                                                        $fileUrl = '/userfiles/registration/' . rawurlencode($fileName);
+                                                    ?>
+                                                        <a href="<?= htmlspecialchars($fileUrl, ENT_QUOTES) ?>"
+                                                            download="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>"
+                                                            class="download-link">
+                                                            <?= htmlspecialchars($fileName, ENT_QUOTES) ?>
+                                                        </a><br>
+                                                    <?php endforeach; ?>
+                                                <?php else: ?>
+                                                    <span class="no-file">파일이 없습니다.</span>
+                                                <?php endif; ?>
                                                                                                                     </td>
                                                                                                                 </tr>
                                                                                                             </tbody>


### PR DESCRIPTION
## Summary
- allow multiple file selection for personal application
- support processing multiple files in applicate controller
- display all uploaded files in license history page

## Testing
- `php -l controller/applicate_controller.php`
- `php -l center/center_sub_apply.php`
- `php -l mypage/history_view_license.html`

------
https://chatgpt.com/codex/tasks/task_e_686e36741fe08322bf9ca966d9305f0b