### PR TITLE
Add marketing consent handling

### DIFF
--- a/Madmin/member/member_input.php
+++ b/Madmin/member/member_input.php
@@ -28,6 +28,7 @@ $row = [
     'f_password' => '',
     'f_email' => '',
     'f_email_consent' => 'Y',
+    'f_marketing_agree' => 'N',
     'wdate' => ''
 ];
 
@@ -187,6 +188,15 @@ if ($idx) {
                             <select name="f_email_consent" class="form-control" style="width:auto;">
                                 <option value="Y" <?= $row['f_email_consent'] == 'Y' ? 'selected' : '' ?>>Y</option>
                                 <option value="N" <?= $row['f_email_consent'] == 'N' ? 'selected' : '' ?>>N</option>
+                            </select>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th>마케팅 동의</th>
+                        <td class="comALeft">
+                            <select name="f_marketing_agree" class="form-control" style="width:auto;">
+                                <option value="Y" <?= $row['f_marketing_agree'] == 'Y' ? 'selected' : '' ?>>Y</option>
+                                <option value="N" <?= $row['f_marketing_agree'] == 'N' ? 'selected' : '' ?>>N</option>
                             </select>
                         </td>
                     </tr>

--- a/controller/member_controller.php
+++ b/controller/member_controller.php
@@ -161,6 +161,7 @@ if ($filtered['mode'] === 'sign_up') {
             'f_password' => password_hash($filtered['f_password'], PASSWORD_DEFAULT),
             'f_email' => $filtered['f_email'],
             'f_email_consent' => ($filtered['f_email_consent'] === 'Y' ? 'Y' : 'N'),
+            'f_marketing_agree' => ($filtered['f_marketing_agree'] ?? '') === 'Y' ? 'Y' : 'N',
         ];
 
         $sql = "INSERT INTO df_site_member (
@@ -178,7 +179,8 @@ if ($filtered['mode'] === 'sign_up') {
                 f_user_id,
                 f_password,
                 f_email,
-                f_email_consent
+                f_email_consent,
+                f_marketing_agree
             ) VALUES (
                 :f_member_type,
                 :f_user_name,
@@ -194,7 +196,8 @@ if ($filtered['mode'] === 'sign_up') {
                 :f_user_id,
                 :f_password,
                 :f_email,
-                :f_email_consent
+                :f_email_consent,
+                :f_marketing_agree
             )
         ";
 
@@ -293,6 +296,7 @@ if ($filtered['mode'] === 'sign_up') {
             'f_password' => password_hash($filtered['f_password'], PASSWORD_DEFAULT),
             'f_email' => $filtered['f_email'],
             'f_email_consent' => ($filtered['f_email_consent'] === 'Y' ? 'Y' : 'N'),
+            'f_marketing_agree' => ($filtered['f_marketing_agree'] ?? '') === 'Y' ? 'Y' : 'N',
         ];
 
         $sql = "
@@ -308,7 +312,8 @@ if ($filtered['mode'] === 'sign_up') {
             f_user_id,
             f_password,
             f_email,
-            f_email_consent
+            f_email_consent,
+            f_marketing_agree
         ) VALUES (
             :f_member_type,
             :f_org_name,
@@ -321,7 +326,8 @@ if ($filtered['mode'] === 'sign_up') {
             :f_user_id,
             :f_password,
             :f_email,
-            :f_email_consent
+            :f_email_consent,
+            :f_marketing_agree
         )
     ";
         if (!$db->query($sql, $params)) {
@@ -469,6 +475,7 @@ if ($filtered['mode'] === 'modify_profile') {
             'f_address2 = :f_address2',
             'f_email = :f_email',
             'f_email_consent = :f_email_consent',
+            'f_marketing_agree = :f_marketing_agree',
             'f_affiliation_flag = :f_affiliation_flag',
             'f_affiliation_name = :f_affiliation_name'
         ];
@@ -488,6 +495,7 @@ if ($filtered['mode'] === 'modify_profile') {
             'f_address2' => $filtered['f_address2'] ?? null,
             'f_email' => $filtered['f_email'],
             'f_email_consent' => ($filtered['f_email_consent'] === 'Y' ? 'Y' : 'N'),
+            'f_marketing_agree' => ($filtered['f_marketing_agree'] === 'Y' ? 'Y' : 'N'),
             'f_affiliation_flag' => ($filtered['f_affiliation_flag'] === 'Y' ? 'Y' : 'N'),
             'f_affiliation_name' => $filtered['f_affiliation_name'] ?? null,
             'f_user_id' => $_SESSION['kbga_user_id']
@@ -533,7 +541,8 @@ if ($filtered['mode'] === 'modify_profile') {
             'f_address1       = :f_address1',
             'f_address2       = :f_address2',
             'f_email          = :f_email',
-            'f_email_consent  = :f_email_consent'
+            'f_email_consent  = :f_email_consent',
+            'f_marketing_agree  = :f_marketing_agree'
         ];
 
         $params = [
@@ -546,6 +555,7 @@ if ($filtered['mode'] === 'modify_profile') {
             'f_address2' => $filtered['f_address2'] ?? null,
             'f_email' => $filtered['f_email'],
             'f_email_consent' => ($filtered['f_email_consent'] === 'Y' ? 'Y' : 'N'),
+            'f_marketing_agree' => ($filtered['f_marketing_agree'] === 'Y' ? 'Y' : 'N'),
             'f_user_id' => $_SESSION['kbga_user_id']
         ];
 

--- a/member/join_step02_group.html
+++ b/member/join_step02_group.html
@@ -482,7 +482,7 @@
 														<tr>
 															<td align="left" class="check_td">
 																<label class="checkbox_label">
-																	<input type="checkbox" name="" />
+																	<input type="checkbox" name="f_marketing_agree" value="Y" />
 																	<div class="check_icon"></div>
 																	<span>
 																		[선택] 마케팅 목적의 개인정보 수집 동의

--- a/member/join_step02_individual.html
+++ b/member/join_step02_individual.html
@@ -722,7 +722,7 @@
 														<tr>
 															<td align="left" class="check_td">
 																<label class="checkbox_label">
-																	<input type="checkbox" name="" />
+                                        <input type="checkbox" name="f_marketing_agree" value="Y" />
 																	<div class="check_icon"></div>
 																	<span>
 																		[필수] 개인정보 수집 및 이용 동의
@@ -770,7 +770,7 @@
 														<tr>
 															<td align="left" class="check_td">
 																<label class="checkbox_label">
-																	<input type="checkbox" name="" />
+																	<input type="checkbox" name="f_marketing_agree" value="Y" />
 																	<div class="check_icon"></div>
 																	<span>
 																		[선택] 마케팅 목적의 개인정보 수집 동의

--- a/mypage/modify.html
+++ b/mypage/modify.html
@@ -787,6 +787,41 @@ list($emailId, $emailDomain) = explode('@', $row['f_email']);
                                                                                             </tbody>
                                                                                         </table>
                                                                                     </div>
+<div class="intro_con">
+    <table cellpadding="0" cellspacing="0">
+        <tbody>
+            <tr>
+                <td align="left" class="text_td">
+                    <span>
+                        마케팅 정보 수신 동의
+                    </span>
+                </td>
+                <td align="left" class="check_td">
+                    <ul>
+                        <li>
+                            <label class="radio_label">
+                                <input type="radio" name="f_marketing_agree" value="Y" <?= $row['f_marketing_agree'] === 'Y' ? 'checked' : '' ?> />
+                                <div class="check_icon"></div>
+                                <span>
+                                    동의함
+                                </span>
+                            </label>
+                        </li>
+                        <li>
+                            <label class="radio_label">
+                                <input type="radio" name="f_marketing_agree" value="N" <?= $row['f_marketing_agree'] === 'N' ? 'checked' : '' ?> />
+                                <div class="check_icon"></div>
+                                <span>
+                                    동의안함
+                                </span>
+                            </label>
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
                                                                                 </div>
                                                                             </td>
                                                                         </tr>
@@ -1476,6 +1511,41 @@ list($emailId, $emailDomain) = explode('@', $row['f_email']);
                                                                                                 </tbody>
                                                                                             </table>
                                                                                         </div>
+<div class="intro_con">
+    <table cellpadding="0" cellspacing="0">
+        <tbody>
+            <tr>
+                <td align="left" class="text_td">
+                    <span>
+                        마케팅 정보 수신 동의
+                    </span>
+                </td>
+                <td align="left" class="check_td">
+                    <ul>
+                        <li>
+                            <label class="radio_label">
+                                <input type="radio" name="f_marketing_agree" value="Y" <?= $row['f_marketing_agree'] === 'Y' ? 'checked' : '' ?> />
+                                <div class="check_icon"></div>
+                                <span>
+                                    동의함
+                                </span>
+                            </label>
+                        </li>
+                        <li>
+                            <label class="radio_label">
+                                <input type="radio" name="f_marketing_agree" value="N" <?= $row['f_marketing_agree'] === 'N' ? 'checked' : '' ?> />
+                                <div class="check_icon"></div>
+                                <span>
+                                    동의안함
+                                </span>
+                            </label>
+                        </li>
+                    </ul>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+</div>
                                                                                     </div>
                                                                                 </td>
                                                                             </tr>


### PR DESCRIPTION
## Summary
- handle marketing consent in member sign up controller
- save marketing preference on profile edit
- expose marketing consent on admin member page
- add marketing consent field to join and modify forms

## Testing
- `php -l controller/member_controller.php`
- `php -l Madmin/member/member_input.php`


------
https://chatgpt.com/codex/tasks/task_e_686f22e332348322b8e37069a75ccb94