### PR TITLE
Update cancel form with table selection

### DIFF
--- a/mypage/application_cancel.php
+++ b/mypage/application_cancel.php
@@ -3,25 +3,20 @@ include $_SERVER['DOCUMENT_ROOT'] . '/inc/global.inc';
 include $_SERVER['DOCUMENT_ROOT'] . '/inc/util_lib.inc';
 
 $idx = isset($_POST['idx']) ? (int) $_POST['idx'] : 0;
-if ($idx <= 0) {
+$tableKey = $_POST['table'] ?? '';
+
+$tableMap = [
+    'application' => 'df_site_application_registration',
+    'education'   => 'df_site_edu_registration',
+    'competition' => 'df_site_competition_registration',
+];
+
+if ($idx <= 0 || !isset($tableMap[$tableKey])) {
     error('잘못된 접근입니다.');
 }
 
-$table = null;
-$row = $db->row('SELECT f_applicant_status FROM df_site_application_registration WHERE idx=:idx', ['idx' => $idx]);
-if ($row) {
-    $table = 'df_site_application_registration';
-} else {
-    $row = $db->row('SELECT f_applicant_status FROM df_site_edu_registration WHERE idx=:idx', ['idx' => $idx]);
-    if ($row) {
-        $table = 'df_site_edu_registration';
-    } else {
-        $row = $db->row('SELECT f_applicant_status FROM df_site_competition_registration WHERE idx=:idx', ['idx' => $idx]);
-        if ($row) {
-            $table = 'df_site_competition_registration';
-        }
-    }
-}
+$table = $tableMap[$tableKey];
+$row   = $db->row("SELECT f_applicant_status FROM {$table} WHERE idx=:idx", ['idx' => $idx]);
 
 if (!$row) {
     error('신청 정보를 찾을 수 없습니다.');

--- a/mypage/history_view_contest.html
+++ b/mypage/history_view_contest.html
@@ -1082,7 +1082,7 @@ $p_value = implode(', ', $labels);
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>); return false;">신청취소</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'competition'); return false;">신청취소</a>
 
                                     <a href="/mypage/history.html" class="a_btn a_btn02">
                                         목록으로
@@ -1101,6 +1101,7 @@ $p_value = implode(', ', $labels);
 
 <form id="cancelForm" action="/mypage/application_cancel.php" method="post" style="display:none;">
     <input type="hidden" name="idx" value="">
+    <input type="hidden" name="table" value="competition">
 </form>
 
 <script type="text/javascript" language="javascript">
@@ -1189,9 +1190,10 @@ $p_value = implode(', ', $labels);
                 $(this).closest('.apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li .file_div').find("input[name='upfile_name']").val(fileName);
         });
 
-        function submitCancelForm(idx) {
+        function submitCancelForm(idx, table) {
             const form = document.getElementById('cancelForm');
             form.idx.value = idx;
+            form.table.value = table;
             form.submit();
         }
 </script>

--- a/mypage/history_view_license.html
+++ b/mypage/history_view_license.html
@@ -1433,7 +1433,7 @@ $p_value = implode(', ', $labels);
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>); return false;">신청취소</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'application'); return false;">신청취소</a>
 
                                     <a href="/mypage/history.html" class="a_btn a_btn02">
                                         목록으로
@@ -1452,6 +1452,7 @@ $p_value = implode(', ', $labels);
 
 <form id="cancelForm" action="/mypage/application_cancel.php" method="post" style="display:none;">
     <input type="hidden" name="idx" value="">
+    <input type="hidden" name="table" value="application">
 </form>
 
 <script type="text/javascript" language="javascript">
@@ -1498,9 +1499,10 @@ $p_value = implode(', ', $labels);
         $(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td .input_con > table > tbody > tr > .input_td .input").val(val).focus();
     }
 
-    function submitCancelForm(idx) {
+    function submitCancelForm(idx, table) {
         const form = document.getElementById('cancelForm');
         form.idx.value = idx;
+        form.table.value = table;
         form.submit();
     }
 </script>


### PR DESCRIPTION
## Summary
- add table parameter to contest and license cancel forms
- send table name in cancel request
- simplify application_cancel.php by validating the table value

## Testing
- `php -l mypage/application_cancel.php`

------
https://chatgpt.com/codex/tasks/task_e_686f4ccc0bc483229c63fdbdfce3758f