### PR TITLE
Implement file update on history views

### DIFF
--- a/controller/history_update_controller.php
+++ b/controller/history_update_controller.php
@@ -1,0 +1,151 @@
+<?php
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/global.inc';
+include $_SERVER['DOCUMENT_ROOT'] . '/inc/util_lib.inc';
+
+function auto_filter_input(string $data)
+{
+    return SQL_Injection(RemoveXSS($data));
+}
+
+function return_json(array $ret)
+{
+    header('Content-Type: application/json; charset=utf-8');
+    echo json_encode($ret);
+    exit;
+}
+
+function upload_file(array $file, string $dir): array
+{
+    $orig = $file['name'];
+    $tmp = $file['tmp_name'];
+    $err = $file['error'];
+    if ($err !== UPLOAD_ERR_OK) {
+        return_json(['result' => 'error', 'msg' => '파일 업로드 중 오류가 발생했습니다.']);
+    }
+    $ext = strtolower(pathinfo($orig, PATHINFO_EXTENSION));
+    if (!is_dir($dir)) {
+        mkdir($dir, 0755, true);
+    }
+    $new = uniqid('', true) . '.' . $ext;
+    $dest = $dir . '/' . $new;
+    if (!move_uploaded_file($tmp, $dest)) {
+        return_json(['result' => 'error', 'msg' => '파일 저장에 실패했습니다.']);
+    }
+    return ['saved' => $new, 'original' => $orig];
+}
+
+function upload_files(array $files, string $dir): array
+{
+    $saved = [];
+    if (!isset($files['name']) || !is_array($files['name'])) {
+        return $saved;
+    }
+    $cnt = count($files['name']);
+    for ($i = 0; $i < $cnt; $i++) {
+        if (empty($files['name'][$i])) {
+            continue;
+        }
+        $info = [
+            'name' => $files['name'][$i],
+            'tmp_name' => $files['tmp_name'][$i] ?? '',
+            'error' => $files['error'][$i] ?? UPLOAD_ERR_NO_FILE,
+        ];
+        $saved[] = upload_file($info, $dir);
+    }
+    return $saved;
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    return_json(['result' => 'error', 'msg' => '잘못된 요청입니다.']);
+}
+
+$mode = $_POST['mode'] ?? '';
+$allowed = ['update_license', 'update_education', 'update_contest'];
+if (!in_array($mode, $allowed, true)) {
+    return_json(['result' => 'error', 'msg' => '잘못된 요청입니다.']);
+}
+
+$filtered = [];
+foreach ($_POST as $k => $v) {
+    $filtered[$k] = is_array($v) ? array_map('auto_filter_input', $v) : auto_filter_input($v);
+}
+
+if (empty($filtered['csrf_token']) || $filtered['csrf_token'] !== $_SESSION['csrf_token']) {
+    return_json(['result' => 'error', 'msg' => '잘못된 접근입니다 (CSRF).']);
+}
+
+$idx = (int)($filtered['idx'] ?? 0);
+if ($idx <= 0) {
+    return_json(['result' => 'error', 'msg' => '잘못된 접근입니다.']);
+}
+
+switch ($mode) {
+    case 'update_license':
+        $table = 'df_site_application_registration';
+        $dirName = 'registration';
+        $hasName = true;
+        break;
+    case 'update_education':
+        $table = 'df_site_edu_registration';
+        $dirName = 'education';
+        $hasName = true;
+        break;
+    case 'update_contest':
+        $table = 'df_site_competition_registration';
+        $dirName = 'competition';
+        $hasName = false;
+        break;
+}
+
+$user_id = $_SESSION['kbga_user_id'] ?? '';
+$row = $db->row("SELECT f_issue_file" . ($hasName ? ', f_issue_file_name' : '') . " FROM {$table} WHERE idx=:idx AND f_user_id=:uid", ['idx' => $idx, 'uid' => $user_id]);
+if (!$row) {
+    return_json(['result' => 'error', 'msg' => '정보를 찾을 수 없습니다.']);
+}
+
+$currentFiles = $row['f_issue_file'] ? explode(',', $row['f_issue_file']) : [];
+$currentNames = $hasName ? ($row['f_issue_file_name'] ? explode(',', $row['f_issue_file_name']) : []) : [];
+
+$deleteArr = isset($filtered['delete_files']) ? array_filter(array_map('trim', explode(',', $filtered['delete_files']))) : [];
+$dir = $_SERVER['DOCUMENT_ROOT'] . '/userfiles/' . $dirName;
+
+foreach ($deleteArr as $df) {
+    $key = array_search($df, $currentFiles, true);
+    if ($key !== false) {
+        @unlink($dir . '/' . $currentFiles[$key]);
+        unset($currentFiles[$key]);
+        if ($hasName) {
+            unset($currentNames[$key]);
+        }
+    }
+}
+
+$uploadSaved = [];
+$uploadOriginal = [];
+if (!empty($_FILES['upfile']['name'])) {
+    $uploaded = upload_files($_FILES['upfile'], $dir);
+    if ($uploaded) {
+        $uploadSaved = array_column($uploaded, 'saved');
+        $uploadOriginal = array_column($uploaded, 'original');
+    }
+}
+
+$currentFiles = array_merge($currentFiles, $uploadSaved);
+$currentNames = $hasName ? array_merge($currentNames, $uploadOriginal) : [];
+
+$update = [
+    'file' => $currentFiles ? implode(',', $currentFiles) : null,
+    'name' => $hasName ? ($currentNames ? implode(',', $currentNames) : null) : null,
+];
+
+$params = ['file' => $update['file'], 'idx' => $idx, 'status' => 're'];
+$sql = "UPDATE {$table} SET f_issue_file=:file,";
+if ($hasName) {
+    $sql .= " f_issue_file_name=:name,";
+    $params['name'] = $update['name'];
+}
+$sql .= " f_applicant_status=:status WHERE idx=:idx";
+
+$db->query($sql, $params);
+
+return_json(['result' => 'ok', 'msg' => '수정되었습니다.', 'redirect' => '/mypage/history.html']);

--- a/mypage/history_view_contest.html
+++ b/mypage/history_view_contest.html
@@ -4,6 +4,8 @@ $sMenu = "07-2";
 
 include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
 
+echo '<script src="/js/form-controller.js"></script>';
+
 $idx = (int) ($_GET['idx'] ?? 0);
 $user_id = $_SESSION['kbga_user_id'] ?? '';
 $row = $db->row(
@@ -116,22 +118,24 @@ $p_value = implode(', ', $labels);
                                             </tbody>
                                         </table>
 
-										<div class="reason_con">
-											<table cellpadding="0" cellspacing="0">
+                                       <?php if (!empty($row['f_status_reason'])): ?>
+                                                                               <div class="reason_con">
+                                                                               <table cellpadding="0" cellspacing="0">
 												<tbody>
 													<tr>
 														<td valign="top" align="left" class="icon_td">
 															<img src="/img/sub/reason_icon.svg" alt="사유 아이콘" class="fx" />
 														</td>
 														<td align="top "align="left" class="text_td">
-															<span>
-																해당 신청서가 보류된 사유를 알려드리는 공간입니다.
-															</span>
+                                                                               <span>
+                                                                               <?= htmlspecialchars($row['f_status_reason'], ENT_QUOTES) ?>
+                                                                               </span>
 														</td>
 													</tr>
 												</tbody>
 											</table>
-										</div>
+                                                                               </div>
+                                       <?php endif; ?>
                                     </div>
 
                                     <div class="contents_con">
@@ -140,18 +144,17 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                    <!--
-                                                <form id="applyForm" action="/controller/competition_apply_controller.php" method="post"
-                                                    enctype="multipart/form-data" autocomplete="off">
-                                                    <input type="hidden" name="mode" value="register" />
-                                                    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
-                                                -->
+                                                <form id="updateForm" action="/controller/history_update_controller.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                    <input type="hidden" name="mode" value="update_contest" />
+                                                    <input type="hidden" name="idx" value="<?= $idx ?>" />
+                                                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES) ?>" />
+                                                    <input type="hidden" name="delete_files" id="delete_files" value="" />
                                                     <div class="write_con">
                                                         <div class="contents_con">
                                                             <div class="input_con">
                                                                 <div class="form01_con">
                                                                     <ul>
-                                                                        <li>
+                                                                               <li data-file="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>">
                                                                             <div class="list_div fl">
                                                                                 <table cellpadding="0" cellspacing="0">
                                                                                     <tbody>
@@ -708,9 +711,7 @@ $p_value = implode(', ', $labels);
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <!--
                                                 </form>
-                                                -->
 
                                                 </div>
                                             </div>
@@ -722,12 +723,11 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                    <!--
-                                                <form id="applyForm" action="/controller/competition_apply_controller_o.php" method="post"
-                                                    enctype="multipart/form-data" autocomplete="off">
-                                                    <input type="hidden" name="mode" value="register" />
-                                                    <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
-                                                -->
+                                                <form id="updateForm" action="/controller/history_update_controller.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                    <input type="hidden" name="mode" value="update_contest" />
+                                                    <input type="hidden" name="idx" value="<?= $idx ?>" />
+                                                    <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES) ?>" />
+                                                    <input type="hidden" name="delete_files" id="delete_files" value="" />
                                                     <div class="write_con">
                                                         <div class="contents_con">
                                                             <div class="input_con">
@@ -1364,9 +1364,7 @@ $p_value = implode(', ', $labels);
                                                             </div>
                                                         </div>
                                                     </div>
-                                                    <!--
                                                 </form>
-                                                -->
 
                                                 </div>
                                             </div>
@@ -1375,7 +1373,7 @@ $p_value = implode(', ', $labels);
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="">수정하기</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="submitUpdateForm();">수정하기</a>
 
                                     <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'competition'); return false;">신청취소</a>
 
@@ -1447,8 +1445,9 @@ $p_value = implode(', ', $labels);
 	}
 	*/
 
-	// 추가 버튼 클릭 이벤트
-	$(document).on("click", ".add_btn", function(e){
+        var deleteArr = [];
+        // 추가 버튼 클릭 이벤트
+        $(document).on("click", ".add_btn", function(e){
 		e.preventDefault(); // a 태그 기본동작 방지
 		var lastRow = $(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").last(); // 마지막 li
 		var newRow = lastRow.clone(); // 복제
@@ -1461,11 +1460,14 @@ $p_value = implode(', ', $labels);
 	});
 
 	// 삭제 버튼 클릭 이벤트
-	$(document).on("click", ".delete_btn", function(e){
-		e.preventDefault(); // a 태그 기본동작 방지
-		if($(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").length > 1) {
-			$(this).closest('.file_div').closest('li').remove();
-		}
+        $(document).on("click", ".delete_btn", function(e){
+                e.preventDefault();
+                var li = $(this).closest('li');
+                var file = li.data('file');
+                if (file) { deleteArr.push(file); }
+                if($(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").length > 1) {
+                        li.remove();
+                }
 	});
 
 	// 파일 선택 시 파일명 표시
@@ -1492,6 +1494,11 @@ $p_value = implode(', ', $labels);
         form.idx.value = idx;
         form.table.value = table;
         form.submit();
+    }
+
+    function submitUpdateForm() {
+        document.getElementById('delete_files').value = deleteArr.join(',');
+        submitForm('updateForm');
     }
 </script>
 

--- a/mypage/history_view_education.html
+++ b/mypage/history_view_education.html
@@ -4,6 +4,8 @@ $sMenu = "07-2";
 
 include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
 
+echo '<script src="/js/form-controller.js"></script>';
+
 $idx = (int) ($_GET['idx'] ?? 0);
 $user_id = $_SESSION['kbga_user_id'] ?? '';
 $row = $db->row(
@@ -102,22 +104,24 @@ function printStatus($val)
                                             </tbody>
                                         </table>
 
-										<div class="reason_con">
-											<table cellpadding="0" cellspacing="0">
+                                       <?php if (!empty($row['f_status_reason'])): ?>
+                                                                               <div class="reason_con">
+                                                                               <table cellpadding="0" cellspacing="0">
 												<tbody>
 													<tr>
 														<td valign="top" align="left" class="icon_td">
 															<img src="/img/sub/reason_icon.svg" alt="사유 아이콘" class="fx" />
 														</td>
 														<td align="top "align="left" class="text_td">
-															<span>
-																해당 신청서가 보류된 사유를 알려드리는 공간입니다.
-															</span>
+                                                                               <span>
+                                                                               <?= htmlspecialchars($row['f_status_reason'], ENT_QUOTES) ?>
+                                                                               </span>
 														</td>
 													</tr>
 												</tbody>
 											</table>
-										</div>
+                                                                               </div>
+                                       <?php endif; ?>
                                     </div>
 
                                     <div class="contents_con">
@@ -126,13 +130,17 @@ function printStatus($val)
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                    <form action="" method="" autocomplete="off">
+                                                    <form id="updateForm" action="/controller/history_update_controller.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                        <input type="hidden" name="mode" value="update_education" />
+                                                        <input type="hidden" name="idx" value="<?= $idx ?>" />
+                                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES) ?>" />
+                                                        <input type="hidden" name="delete_files" id="delete_files" value="" />
                                                         <div class="write_con">
                                                             <div class="contents_con">
                                                                 <div class="input_con">
                                                                     <div class="form01_con">
                                                                         <ul>
-                                                                            <li>
+                                                                               <li data-file="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>">
                                                                                 <div class="list_div fl">
                                                                                     <table cellpadding="0" cellspacing="0">
                                                                                         <tbody>
@@ -560,7 +568,11 @@ function printStatus($val)
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                    <form action="" method="" autocomplete="off">
+                                                    <form id="updateForm" action="/controller/history_update_controller.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                        <input type="hidden" name="mode" value="update_education" />
+                                                        <input type="hidden" name="idx" value="<?= $idx ?>" />
+                                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES) ?>" />
+                                                        <input type="hidden" name="delete_files" id="delete_files" value="" />
                                                         <div class="write_con">
                                                             <div class="contents_con">
                                                                 <div class="input_con">
@@ -1072,7 +1084,7 @@ function printStatus($val)
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="">수정하기</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="submitUpdateForm();">수정하기</a>
 
                                     <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'education'); return false;">신청취소</a>
 
@@ -1145,10 +1157,11 @@ function printStatus($val)
 	*/
 
 	// 추가 버튼 클릭 이벤트
-	$(document).on("click", ".add_btn", function(e){
-		e.preventDefault(); // a 태그 기본동작 방지
-		var lastRow = $(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").last(); // 마지막 li
-		var newRow = lastRow.clone(); // 복제
+        var deleteArr = [];
+        $(document).on("click", ".add_btn", function(e){
+                e.preventDefault(); // a 태그 기본동작 방지
+                var lastRow = $(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").last(); // 마지막 li
+                var newRow = lastRow.clone(); // 복제
 		// input[type=file] 비우기
 		newRow.find("input[type='file']").val(""); 
 		// input[type=text] 비우기 (파일명 표시 input)
@@ -1158,11 +1171,14 @@ function printStatus($val)
 	});
 
 	// 삭제 버튼 클릭 이벤트
-	$(document).on("click", ".delete_btn", function(e){
-		e.preventDefault(); // a 태그 기본동작 방지
-		if($(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").length > 1) {
-			$(this).closest('.file_div').closest('li').remove();
-		}
+        $(document).on("click", ".delete_btn", function(e){
+                e.preventDefault();
+                var li = $(this).closest('li');
+                var file = li.data('file');
+                if (file) { deleteArr.push(file); }
+                if($(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").length > 1) {
+                        li.remove();
+                }
 	});
 
 	// 파일 선택 시 파일명 표시
@@ -1189,6 +1205,11 @@ function printStatus($val)
         form.idx.value = idx;
         form.table.value = table;
         form.submit();
+    }
+
+    function submitUpdateForm() {
+        document.getElementById('delete_files').value = deleteArr.join(',');
+        submitForm('updateForm');
     }
 </script>
 

--- a/mypage/history_view_license.html
+++ b/mypage/history_view_license.html
@@ -4,6 +4,8 @@ $sMenu = "07-2";
 
 include $_SERVER['DOCUMENT_ROOT'] . '/include/header.html';
 
+echo '<script src="/js/form-controller.js"></script>';
+
 $idx = (int) ($_GET['idx'] ?? 0);
 $user_id = $_SESSION['kbga_user_id'] ?? '';
 $row = $db->row(
@@ -132,22 +134,24 @@ $p_value = implode(', ', $labels);
                                             </tbody>
                                         </table>
 
-										<div class="reason_con">
-											<table cellpadding="0" cellspacing="0">
+                                       <?php if (!empty($row['f_status_reason'])): ?>
+                                                                               <div class="reason_con">
+                                                                               <table cellpadding="0" cellspacing="0">
 												<tbody>
 													<tr>
 														<td valign="top" align="left" class="icon_td">
 															<img src="/img/sub/reason_icon.svg" alt="사유 아이콘" class="fx" />
 														</td>
 														<td align="top "align="left" class="text_td">
-															<span>
-																해당 신청서가 보류된 사유를 알려드리는 공간입니다.
-															</span>
+                                                                               <span>
+                                                                               <?= htmlspecialchars($row['f_status_reason'], ENT_QUOTES) ?>
+                                                                               </span>
 														</td>
 													</tr>
 												</tbody>
 											</table>
-										</div>
+                                                                               </div>
+                                       <?php endif; ?>
                                     </div>
 
                                     <div class="contents_con">
@@ -156,13 +160,17 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                    <form action="" method="" autocomplete="off">
+                                                    <form id="updateForm" action="/controller/history_update_controller.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                        <input type="hidden" name="mode" value="update_license" />
+                                                        <input type="hidden" name="idx" value="<?= $idx ?>" />
+                                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES) ?>" />
+                                                        <input type="hidden" name="delete_files" id="delete_files" value="" />
                                                         <div class="write_con">
                                                             <div class="contents_con">
                                                                 <div class="input_con">
                                                                     <div class="form01_con">
                                                                         <ul>
-                                                                            <li>
+                                                                               <li data-file="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>">
                                                                                 <div class="list_div fl">
                                                                                     <table cellpadding="0" cellspacing="0">
                                                                                         <tbody>
@@ -192,7 +200,7 @@ $p_value = implode(', ', $labels);
                                                                                     </table>
                                                                                 </div>
                                                                             </li>
-                                                                            <li>
+                                                                               <li data-file="<?= htmlspecialchars($fileName, ENT_QUOTES) ?>">
                                                                                 <div class="list_div fl">
                                                                                     <table cellpadding="0" cellspacing="0">
                                                                                         <tbody>
@@ -861,7 +869,11 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con" style="">
                                                 <div class="contents_con">
 
-                                                    <form action="" method="" autocomplete="off">
+                                                    <form id="updateForm" action="/controller/history_update_controller.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                        <input type="hidden" name="mode" value="update_license" />
+                                                        <input type="hidden" name="idx" value="<?= $idx ?>" />
+                                                        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($csrf_token, ENT_QUOTES) ?>" />
+                                                        <input type="hidden" name="delete_files" id="delete_files" value="" />
                                                         <div class="write_con">
                                                             <div class="contents_con">
                                                                 <div class="input_con">
@@ -1540,7 +1552,7 @@ $p_value = implode(', ', $labels);
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="">수정하기</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="submitUpdateForm();">수정하기</a>
 
                                     <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'application'); return false;">신청취소</a>
 
@@ -1612,8 +1624,9 @@ $p_value = implode(', ', $labels);
 		}
 		*/
 
-		// 추가 버튼 클릭 이벤트
-		$(document).on("click", ".add_btn", function(e){
+                var deleteArr = [];
+                // 추가 버튼 클릭 이벤트
+                $(document).on("click", ".add_btn", function(e){
 			e.preventDefault(); // a 태그 기본동작 방지
 			var lastRow = $(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").last(); // 마지막 li
 			var newRow = lastRow.clone(); // 복제
@@ -1625,13 +1638,18 @@ $p_value = implode(', ', $labels);
 			$(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul").append(newRow);
 		});
 
-		// 삭제 버튼 클릭 이벤트
-		$(document).on("click", ".delete_btn", function(e){
-			e.preventDefault(); // a 태그 기본동작 방지
-			if($(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").length > 1) {
-				$(this).closest('.file_div').closest('li').remove();
-			}
-		});
+                // 삭제 버튼 클릭 이벤트
+                $(document).on("click", ".delete_btn", function(e){
+                        e.preventDefault();
+                        var li = $(this).closest('li');
+                        var file = li.data('file');
+                        if (file) {
+                                deleteArr.push(file);
+                        }
+                        if($(".apply_con > .contents_con .write_con > .contents_con > .input_con .list_div > table > tbody > tr > .info_td .file_con > table > tbody > tr > .info_td > ul > li").length > 1) {
+                                li.remove();
+                        }
+                });
 
 		// 파일 선택 시 파일명 표시
 		function file_upload(val){
@@ -1657,6 +1675,11 @@ $p_value = implode(', ', $labels);
         form.idx.value = idx;
         form.table.value = table;
         form.submit();
+    }
+
+    function submitUpdateForm() {
+        document.getElementById('delete_files').value = deleteArr.join(',');
+        submitForm('updateForm');
     }
 </script>
 


### PR DESCRIPTION
## Summary
- add controller to handle history update requests
- allow file editing on license, education and contest history pages
- hide reason section when no reason text exists
- attach form-controller to history pages

## Testing
- `php -l controller/history_update_controller.php`

------
https://chatgpt.com/codex/tasks/task_e_686f7a2582fc8322a195cebda59d16b1