### PR TITLE
Add modify form submission helper

### DIFF
--- a/mypage/history_view_contest.html
+++ b/mypage/history_view_contest.html
@@ -142,7 +142,7 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                <form id="applyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                <form id="fileModifyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
                                                     <input type="hidden" name="table" value="competition" />
                                                     <input type="hidden" name="idx" value="<?= $idx ?>" />
                                                     <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
@@ -721,7 +721,7 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                <form id="applyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                <form id="fileModifyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
                                                     <input type="hidden" name="table" value="competition" />
                                                     <input type="hidden" name="idx" value="<?= $idx ?>" />
                                                     <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
@@ -1372,7 +1372,7 @@ $p_value = implode(', ', $labels);
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="">수정하기</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="submitModifyForm(); return false;">수정하기</a>
 
                                     <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'competition'); return false;">신청취소</a>
 
@@ -1489,6 +1489,11 @@ $p_value = implode(', ', $labels);
         form.idx.value = idx;
         form.table.value = table;
         form.submit();
+    }
+
+    function submitModifyForm() {
+        const form = document.getElementById('fileModifyForm');
+        if (form) form.submit();
     }
 
     $(function(){

--- a/mypage/history_view_education.html
+++ b/mypage/history_view_education.html
@@ -128,7 +128,7 @@ function printStatus($val)
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                    <form action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                    <form id="fileModifyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
                                                         <input type="hidden" name="table" value="education" />
                                                         <input type="hidden" name="idx" value="<?= $idx ?>" />
                                                         <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
@@ -566,7 +566,7 @@ function printStatus($val)
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                    <form action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                    <form id="fileModifyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
                                                         <input type="hidden" name="table" value="education" />
                                                         <input type="hidden" name="idx" value="<?= $idx ?>" />
                                                         <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
@@ -1083,7 +1083,7 @@ function printStatus($val)
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="">수정하기</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="submitModifyForm(); return false;">수정하기</a>
 
                                     <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'education'); return false;">신청취소</a>
 
@@ -1200,6 +1200,11 @@ function printStatus($val)
         form.idx.value = idx;
         form.table.value = table;
         form.submit();
+    }
+
+    function submitModifyForm() {
+        const form = document.getElementById('fileModifyForm');
+        if (form) form.submit();
     }
 
     $(function(){

--- a/mypage/history_view_license.html
+++ b/mypage/history_view_license.html
@@ -158,7 +158,7 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con">
                                                 <div class="contents_con">
 
-                                                   <form action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                   <form id="fileModifyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
                                                        <input type="hidden" name="table" value="application" />
                                                        <input type="hidden" name="idx" value="<?= $idx ?>" />
                                                        <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
@@ -869,7 +869,7 @@ $p_value = implode(', ', $labels);
                                             <div class="apply_con" style="">
                                                 <div class="contents_con">
 
-                                                    <form action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
+                                                    <form id="fileModifyForm" action="/mypage/file_modify.php" method="post" enctype="multipart/form-data" autocomplete="off">
                                                         <input type="hidden" name="table" value="application" />
                                                         <input type="hidden" name="idx" value="<?= $idx ?>" />
                                                         <input type="hidden" name="csrf_token" value="<?= $csrf_token ?>" />
@@ -1552,7 +1552,7 @@ $p_value = implode(', ', $labels);
                                 </div>
 
                                 <div class="btn_con">
-                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="">수정하기</a>
+                                    <a href="javascript:void(0);" class="a_btn a_btn00" onclick="submitModifyForm(); return false;">수정하기</a>
 
                                     <a href="javascript:void(0);" class="a_btn a_btn01" onclick="submitCancelForm(<?= $idx ?>, 'application'); return false;">신청취소</a>
 
@@ -1669,6 +1669,11 @@ $p_value = implode(', ', $labels);
         form.idx.value = idx;
         form.table.value = table;
         form.submit();
+    }
+
+    function submitModifyForm() {
+        const form = document.getElementById('fileModifyForm');
+        if (form) form.submit();
     }
 
     $(function(){


### PR DESCRIPTION
## Summary
- add `id="fileModifyForm"` to modification forms
- modify "수정하기" buttons to use `submitModifyForm()`
- add helper `submitModifyForm()` to submit forms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fd98b8ca483228539073203a04bd4